### PR TITLE
Factored out common cmake code to moveit_common package

### DIFF
--- a/moveit_common/CMakeLists.txt
+++ b/moveit_common/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(moveit_common NONE)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "moveit_common-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -1,0 +1,41 @@
+macro(moveit_package)
+  if(NOT "${CMAKE_CXX_STANDARD}")
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # Enable warnings
+    add_compile_options(-Wall -Wextra
+      -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual
+      -Wno-unused-parameter -Wno-unused-function)
+  else()
+    add_compile_options(/W3 /wd4251 /wd4068 /wd4275)
+    add_compile_options(/D_USE_MATH_DEFINES)
+  endif()
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # This too often has false-positives
+    add_compile_options(-Wno-maybe-uninitialized)
+  endif()
+
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+  if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
+    set(CMAKE_BUILD_TYPE Release)
+  endif()
+
+  # Defaults for Microsoft C++ compiler
+  if(MSVC)
+    # https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+    # Enable Math Constants
+    # https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=vs-2019
+    add_compile_definitions(
+      _USE_MATH_DEFINES
+    )
+  endif()
+endmacro()

--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -13,6 +13,16 @@ macro(moveit_package)
   else()
     add_compile_options(/W3 /wd4251 /wd4068 /wd4275)
     add_compile_options(/D_USE_MATH_DEFINES)
+
+    # https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+    # Enable Math Constants
+    # https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=vs-2019
+    add_compile_definitions(
+      _USE_MATH_DEFINES
+    )
+
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -25,17 +35,5 @@ macro(moveit_package)
   if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
     message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
     set(CMAKE_BUILD_TYPE Release)
-  endif()
-
-  # Defaults for Microsoft C++ compiler
-  if(MSVC)
-    # https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-    # Enable Math Constants
-    # https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=vs-2019
-    add_compile_definitions(
-      _USE_MATH_DEFINES
-    )
   endif()
 endmacro()

--- a/moveit_common/moveit_common-extras.cmake
+++ b/moveit_common/moveit_common-extras.cmake
@@ -1,0 +1,1 @@
+include("${moveit_common_DIR}/moveit_package.cmake")

--- a/moveit_common/package.xml
+++ b/moveit_common/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>moveit_common</name>
+  <version>2.0.0</version>
+  <description>Common support functionality used throughout MoveIt</description>
+  <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
+
+  <license>BSD</license>
+  <url type="website">http://moveit.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-planning/moveit/issues</url>
+  <url type="repository">https://github.com/ros-planning/moveit</url>
+
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -1,35 +1,11 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_core VERSION 2.0.0 LANGUAGES CXX)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # Enable warnings
-  add_compile_options(-Wall -Wextra
-    -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual
-    -Wno-unused-parameter -Wno-unused-function)
-else()
-  add_compile_options(/W3 /wd4251 /wd4068 /wd4275)
-  add_compile_options(/D_USE_MATH_DEFINES)
-endif()
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  # This too often has false-positives
-  add_compile_options(-Wno-maybe-uninitialized)
-endif()
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
-  set(CMAKE_BUILD_TYPE Release)
-endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
+moveit_package()
+
 find_package(rclcpp REQUIRED)
 find_package(Boost REQUIRED system filesystem date_time thread iostreams regex ${EXTRA_BOOST_COMPONENTS})
 
@@ -37,6 +13,9 @@ find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+
+#find_package(MOVEIT_COMMON REQUIRED)
+#moveit_package()
 
 # TODO(henningkayser): enable bullet once the library is migrated to ROS2
 # TODO: Move collision detection into separate packages

--- a/moveit_core/background_processing/CMakeLists.txt
+++ b/moveit_core/background_processing/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_background_processing)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/background_processing.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost
   rclcpp

--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -11,7 +11,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(${MOVEIT_LIB_NAME}
   src/bullet_integration/bullet_bvh_manager.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection
     ${catkin_LIBRARIES} ${urdfdom_LIBRARIES}

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/collision_env_fcl.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   rmw_implementation
@@ -29,7 +28,6 @@ target_compile_definitions(${MOVEIT_LIB_NAME}
 
 add_library(collision_detector_fcl_plugin SHARED src/collision_detector_fcl_plugin_loader.cpp)
 set_target_properties(collision_detector_fcl_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(collision_detector_fcl_plugin PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(collision_detector_fcl_plugin
   rclcpp
   urdf

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/collision_env_hybrid.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/union_constraint_sampler.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf
   urdfdom

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -7,8 +7,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost
   urdfdom

--- a/moveit_core/dynamics_solver/CMakeLists.txt
+++ b/moveit_core/dynamics_solver/CMakeLists.txt
@@ -2,8 +2,6 @@ set(MOVEIT_LIB_NAME moveit_dynamics_solver)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/dynamics_solver.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf
   urdfdom_headers

--- a/moveit_core/exceptions/CMakeLists.txt
+++ b/moveit_core/exceptions/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_exceptions)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/exceptions.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost
   rclcpp

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -12,7 +12,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -3,7 +3,6 @@ set(MOVEIT_LIB_NAME moveit_kinematics_base)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/kinematics_base.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 # This line is needed to ensure that messages are done being built before this is built
 ament_target_dependencies(${MOVEIT_LIB_NAME} rclcpp urdf urdfdom_headers moveit_msgs geometry_msgs Boost)

--- a/moveit_core/kinematics_metrics/CMakeLists.txt
+++ b/moveit_core/kinematics_metrics/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_kinematics_metrics)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/kinematics_metrics.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -21,6 +21,7 @@
   <buildtool_depend>pkg-config</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>rclcpp</depend>
   <depend>common_interfaces</depend>

--- a/moveit_core/planning_interface/CMakeLists.txt
+++ b/moveit_core/planning_interface/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/planning_response.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_msgs
   urdf

--- a/moveit_core/planning_request_adapter/CMakeLists.txt
+++ b/moveit_core/planning_request_adapter/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_planning_request_adapter)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/planning_request_adapter.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   rmw_implementation

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -12,7 +12,6 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   OCTOMAP
 )
 
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_model
   moveit_robot_state

--- a/moveit_core/profiler/CMakeLists.txt
+++ b/moveit_core/profiler/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_profiler)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/profiler.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/robot_model.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_msgs
   Eigen3

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -12,7 +12,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/cartesian_interpolator.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf
   tf2_geometry_msgs

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   rmw_implementation

--- a/moveit_core/transforms/CMakeLists.txt
+++ b/moveit_core/transforms/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_transforms)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/transforms.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   geometric_shapes

--- a/moveit_demo_nodes/run_move_group/CMakeLists.txt
+++ b/moveit_demo_nodes/run_move_group/CMakeLists.txt
@@ -1,17 +1,15 @@
 cmake_minimum_required(VERSION 3.5)
 project(run_move_group)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wpedantic)
 endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
+
+moveit_package()
 
 find_package(moveit_ros_planning_interface REQUIRED)
 # This shouldn't be necessary (required by moveit_simple_controller_manager)

--- a/moveit_demo_nodes/run_move_group/package.xml
+++ b/moveit_demo_nodes/run_move_group/package.xml
@@ -8,6 +8,7 @@
   <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_ros_planning_interface</depend>
 

--- a/moveit_demo_nodes/run_moveit_cpp/CMakeLists.txt
+++ b/moveit_demo_nodes/run_moveit_cpp/CMakeLists.txt
@@ -1,22 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(run_moveit_cpp)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wpedantic)
 endif()
-
-if (WIN32)
-  add_compile_options(/wd4251 /wd4068 /wd4275)
-endif()
-
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 # This shouldn't be necessary (required by moveit_simple_controller_manager)
 find_package(rosidl_default_runtime REQUIRED)
@@ -24,6 +15,8 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
+
+moveit_package()
 
 add_executable(run_moveit_cpp src/run_moveit_cpp.cpp)
 ament_target_dependencies(run_moveit_cpp

--- a/moveit_demo_nodes/run_moveit_cpp/package.xml
+++ b/moveit_demo_nodes/run_moveit_cpp/package.xml
@@ -8,6 +8,7 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_ros_planning_interface</depend>
 

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/CMakeLists.txt
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(${MOVEIT_LIB_NAME}
   src/kinematics_cache.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -1,21 +1,10 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_kinematics)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if (WIN32)
-  add_compile_options(/wd4251 /wd4068 /wd4275)
-endif()
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
+
+moveit_package()
 
 find_package(Boost REQUIRED program_options system filesystem regex)
 find_package(Eigen3 REQUIRED)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(Boost COMPONENTS filesystem program_options REQUIRED)
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_base)
 add_library(${MOVEIT_LIB_NAME} SHARED src/ik_cache.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   moveit_core
@@ -25,7 +24,6 @@ endif()
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_plugin)
 add_library(${MOVEIT_LIB_NAME} SHARED src/cached_ik_kinematics_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   moveit_core
@@ -52,7 +50,6 @@ if(ur_kinematics_FOUND)
         set(MOVEIT_LIB_NAME moveit_cached_ur${UR}_kinematics_plugin)
         add_library(${MOVEIT_LIB_NAME} SHARED src/cached_ur_kinematics_plugin.cpp)
         set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-        set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
         find_library(ur${UR}_pluginlib ur${UR}_moveit_plugin PATHS ${ur_kinematics_LIBRARY_DIRS})
         target_link_libraries(${MOVEIT_LIB_NAME}
             moveit_cached_ik_kinematics_base

--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -4,8 +4,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/kdl_kinematics_plugin.cpp
   src/chainiksolver_vel_mimic_svd.cpp)
 
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   random_numbers

--- a/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_lma_kinematics_plugin)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/lma_kinematics_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -20,6 +20,7 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>
   <depend>class_loader</depend>

--- a/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_srv_kinematics_plugin)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/srv_kinematics_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -1,24 +1,16 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_planners_ompl)
 
-# At least C++11 required for OMPL
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(Boost REQUIRED system filesystem date_time thread serialization)
+find_package(moveit_common REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(ompl REQUIRED)
+
+moveit_package()
 
 include_directories(ompl_interface/include)
 include_directories(SYSTEM

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -20,7 +20,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/detail/constrained_goal_sampler.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 find_package(OpenMP REQUIRED)
 
@@ -43,7 +42,6 @@ set_target_properties(moveit_generate_state_database PROPERTIES OUTPUT_NAME "gen
 
 add_library(moveit_ompl_planner_plugin SHARED src/ompl_planner_manager.cpp)
 set_target_properties(moveit_ompl_planner_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(moveit_ompl_planner_plugin PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(moveit_ompl_planner_plugin
   moveit_core
   moveit_ros_planning

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -15,6 +15,7 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>
   <depend>ompl</depend>

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -1,23 +1,16 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_simple_controller_manager)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(Boost REQUIRED thread)
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(control_msgs REQUIRED)
 find_package(rclcpp_action REQUIRED)
+
+moveit_package()
 
 include_directories(include)
 
@@ -26,7 +19,6 @@ add_library(${PROJECT_NAME} SHARED
   src/follow_joint_trajectory_controller_handle.cpp
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   control_msgs

--- a/moveit_plugins/moveit_simple_controller_manager/package.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/package.xml
@@ -16,6 +16,7 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>
   <depend>rclcpp</depend>

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -3,21 +3,12 @@ project(moveit_ros_benchmarks)
 
 set(MOVEIT_LIB_NAME moveit_ros_benchmarks)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(Boost REQUIRED date_time filesystem)
 find_package(tf2_eigen REQUIRED)
@@ -26,6 +17,8 @@ find_package(moveit_ros_planning REQUIRED)
 # find_package(moveit_ros_warehouse REQUIRED)
 find_package(pluginlib REQUIRED)
 
+moveit_package()
+
 include_directories(include)
 
 add_library(${MOVEIT_LIB_NAME} SHARED
@@ -33,7 +26,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/BenchmarkExecutor.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   Boost

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -16,6 +16,7 @@
   <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <build_depend>libboost-dev</build_depend>
   <build_depend>libboost-date-time-dev</build_depend>

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -54,6 +54,7 @@
 #else
 #define NOMINMAX
 #include <winsock2.h>
+#pragma comment(lib, "Ws2_32.lib")
 #endif
 
 using namespace moveit_ros_benchmarks;

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -1,16 +1,9 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_move_group)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(Boost REQUIRED system filesystem date_time program_options thread)
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -21,12 +14,13 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
+moveit_package()
+
 add_library(moveit_move_group_capabilities_base SHARED src/move_group_context.cpp
   src/move_group_capability.cpp)
 set_target_properties(moveit_move_group_capabilities_base
   PROPERTIES
   VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(moveit_move_group_capabilities_base PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_include_directories(moveit_move_group_capabilities_base PUBLIC include)
 ament_target_dependencies(moveit_move_group_capabilities_base
   rclcpp moveit_core moveit_ros_planning tf2_geometry_msgs)
@@ -62,7 +56,6 @@ add_library(moveit_move_group_default_capabilities SHARED
 set_target_properties(moveit_move_group_default_capabilities
   PROPERTIES
   VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(moveit_move_group_default_capabilities PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_include_directories(moveit_move_group_default_capabilities PUBLIC include)
 ament_target_dependencies(moveit_move_group_default_capabilities
   rclcpp rclcpp_action moveit_core moveit_ros_planning std_srvs)

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -16,6 +16,7 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -1,15 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(moveit_servo)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 set(LIBRARY_NAME moveit_servo)
 set(COMPOSABLE_NODE_NAME servo_server)
 
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -20,6 +16,8 @@ find_package(moveit_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
+
+moveit_package()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -19,6 +19,9 @@
   <author email="tyler@picknik.ai">Tyler Weaver</author>
   <author email="adam.pettinger@utexas.edu">Adam Pettinger</author>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
+
   <depend>control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -2,27 +2,16 @@ cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_occupancy_map_monitor)
 set(MOVEIT_LIB_NAME ${PROJECT_NAME})
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 # Disable -Wpedantic warnings due to the warnings in ros-dashing-octomap
 # TODO: add -Wpedantic warnings back when PR(https://github.com/OctoMap/octomap/pull/275) is merged
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wno-pedantic)
-endif()
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  add_compile_options(/W3 /wd4251 /wd4068 /wd4275)
-endif()
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+  add_compile_options(-Wno-pedantic)
 endif()
 
 find_package(Boost REQUIRED thread)
+find_package(moveit_common REQUIRED)
+
+moveit_package()
 
 if(APPLE)
   find_package(X11 REQUIRED)
@@ -47,7 +36,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/occupancy_map_updater.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   moveit_core

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -1,22 +1,9 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_planning)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if (WIN32)
-  add_compile_options(/wd4251 /wd4068 /wd4275)
-endif()
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(Boost REQUIRED system filesystem date_time program_options thread chrono)
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(moveit_msgs REQUIRED)
 # find_package(moveit_ros_perception REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -33,6 +20,8 @@ find_package(Eigen3 REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(moveit_ros_occupancy_map_monitor REQUIRED)
+
+moveit_package()
 
 set(THIS_PACKAGE_INCLUDE_DIRS
     rdf_loader/include

--- a/moveit_ros/planning/collision_plugin_loader/CMakeLists.txt
+++ b/moveit_ros/planning/collision_plugin_loader/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_collision_plugin_loader)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/collision_plugin_loader.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_core
   rclcpp

--- a/moveit_ros/planning/constraint_sampler_manager_loader/CMakeLists.txt
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
     src/constraint_sampler_manager_loader.cpp)
 
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_core
   rclcpp

--- a/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
+++ b/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_kinematics_plugin_loader)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/kinematics_plugin_loader.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   urdf

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -18,6 +18,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 

--- a/moveit_ros/planning/plan_execution/CMakeLists.txt
+++ b/moveit_ros/planning/plan_execution/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/plan_with_sensing.cpp
   src/plan_execution.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME}
     moveit_planning_pipeline
     moveit_planning_scene_monitor

--- a/moveit_ros/planning/planning_pipeline/CMakeLists.txt
+++ b/moveit_ros/planning/planning_pipeline/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_planning_pipeline)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/planning_pipeline.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -15,7 +15,6 @@ set(SOURCE_FILES
 add_library(${MOVEIT_LIB_NAME} SHARED ${SOURCE_FILES})
 
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost
   moveit_core

--- a/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
+++ b/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
@@ -6,7 +6,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/trajectory_monitor.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_ros_occupancy_map_monitor
   message_filters

--- a/moveit_ros/planning/rdf_loader/CMakeLists.txt
+++ b/moveit_ros/planning/rdf_loader/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_rdf_loader)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/rdf_loader.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
       rclcpp
       ament_index_cpp

--- a/moveit_ros/planning/robot_model_loader/CMakeLists.txt
+++ b/moveit_ros/planning/robot_model_loader/CMakeLists.txt
@@ -6,7 +6,6 @@ endif()
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/robot_model_loader.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   urdf

--- a/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
+++ b/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_trajectory_execution_manager)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/trajectory_execution_manager.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_planning_interface)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
@@ -26,6 +17,8 @@ find_package(tf2_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclpy REQUIRED)
+
+moveit_package()
 
 # find_package(PythonInterp REQUIRED)
 # find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)

--- a/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
@@ -1,14 +1,9 @@
 set(MOVEIT_LIB_NAME moveit_common_planning_interface_objects)
 
-if (WIN32)
-  add_compile_options(/wd4251 /wd4068 /wd4275)
-endif()
-
 find_package(Boost REQUIRED COMPONENTS thread)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/common_objects.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
     Boost

--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_move_group_interface)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/move_group_interface.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/moveit_ros/planning_interface/moveit_cpp/CMakeLists.txt
+++ b/moveit_ros/planning_interface/moveit_cpp/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/planning_component.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -18,6 +18,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>

--- a/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
@@ -2,7 +2,6 @@ set(MOVEIT_LIB_NAME moveit_planning_scene_interface)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/planning_scene_interface.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(${MOVEIT_LIB_NAME} moveit_msgs moveit_core moveit_ros_move_group)
 
 # TODO(JafarAbdi): Support python wrapper

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_robot_interaction)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(Boost REQUIRED thread)
+find_package(moveit_common REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(interactive_markers REQUIRED)
 find_package(tf2 REQUIRED)
@@ -19,6 +10,8 @@ find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(rclcpp REQUIRED)
+
+moveit_package()
 
 set(MOVEIT_LIB_NAME moveit_robot_interaction)
 
@@ -33,7 +26,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/robot_interaction.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -16,6 +16,7 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_ros_planning</depend>
   <depend>rclcpp</depend>

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_visualization)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # suppress warning in Ogre
   add_compile_options(-Wno-deprecated-register)
@@ -15,12 +9,9 @@ endif()
 # definition needed for boost/math/constants/constants.hpp included by Ogre to compile
 add_definitions(-DBOOST_MATH_DISABLE_FLOAT128)
 
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(Boost REQUIRED thread date_time system filesystem)
 find_package(ament_cmake REQUIRED)
+find_package(moveit_common REQUIRED)
 find_package(class_loader REQUIRED)
 find_package(geometric_shapes REQUIRED)
 find_package(interactive_markers REQUIRED)
@@ -44,6 +35,8 @@ find_package(Eigen3 REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_default_plugins REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
+
+moveit_package()
 
 # Qt Stuff
 find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -34,7 +34,6 @@ set(SOURCE_FILES
 set(MOVEIT_LIB_NAME moveit_motion_planning_rviz_plugin)
 add_library(${MOVEIT_LIB_NAME}_core SHARED ${SOURCE_FILES} ${HEADERS} ${UIC_FILES})
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools moveit_planning_scene_rviz_plugin)
 ament_target_dependencies(${MOVEIT_LIB_NAME}_core
   Boost
@@ -48,7 +47,6 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}_core
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -19,6 +19,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <build_depend>class_loader</build_depend>
   <build_depend>eigen</build_depend>

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(${MOVEIT_LIB_NAME}_core SHARED
   src/planning_scene_display.cpp
   include/moveit/planning_scene_rviz_plugin/planning_scene_display.h)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -24,7 +23,6 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}_core
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core  Qt5::Widgets)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
     pluginlib

--- a/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
@@ -3,7 +3,6 @@ add_library(${MOVEIT_LIB_NAME}_core SHARED
   src/robot_state_display.cpp
   include/moveit/robot_state_rviz_plugin/robot_state_display.h)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME}_core
     moveit_rviz_plugin_render_tools
 )
@@ -18,7 +17,6 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}_core
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
     rclcpp

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -25,7 +25,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   ${HEADERS}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 target_link_libraries(${MOVEIT_LIB_NAME}
     Qt5::Widgets

--- a/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(${MOVEIT_LIB_NAME}_core SHARED
   ${HEADERS}
 )
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
@@ -31,7 +30,6 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}_core
 # Plugin Initializer
 add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
     rclcpp


### PR DESCRIPTION
### Description

Created the moveit_common package including a moveit_package() macro is used to apply basic cmake code to all moveit packages.

This allows CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to be set for all moveit packages and allows for any new cmake code to be applied to all packages easily in the future.

Similar idea to this commit in nav2:
https://github.com/ms-iot/navigation2/commit/3f65576a98330de0cb832d2c344474b2b604142d

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
