### PR TITLE
Replace boost::bind with std::bind

### DIFF
--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -49,7 +49,7 @@ BackgroundProcessing::BackgroundProcessing()
   // spin a thread that will process user events
   run_processing_thread_ = true;
   processing_ = false;
-  processing_thread_.reset(new boost::thread(boost::bind(&BackgroundProcessing::processingThread, this)));
+  processing_thread_.reset(new boost::thread(std::bind(&BackgroundProcessing::processingThread, this)));
 }
 
 BackgroundProcessing::~BackgroundProcessing()

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -35,7 +35,6 @@
 /* Author: Ioan Sucan, E. Gil Jones */
 
 #include <moveit/collision_detection/collision_matrix.h>
-#include <boost/bind.hpp>
 #include <iomanip>
 #include "rclcpp/rclcpp.hpp"
 
@@ -281,7 +280,7 @@ bool AllowedCollisionMatrix::getAllowedCollision(const std::string& name1, const
     else if (!found1 && found2)
       fn = fn2;
     else if (found1 && found2)
-      fn = boost::bind(&andDecideContact, fn1, fn2, boost::placeholders::_1);
+      fn = std::bind(&andDecideContact, fn1, fn2, std::placeholders::_1);
     else
       return false;
     return true;

--- a/moveit_core/collision_detection/src/world_diff.cpp
+++ b/moveit_core/collision_detection/src/world_diff.cpp
@@ -52,7 +52,7 @@ WorldDiff::WorldDiff()
 
 WorldDiff::WorldDiff(const WorldPtr& world) : world_(world)
 {
-  observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = world->addObserver(std::bind(&WorldDiff::notify, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 WorldDiff::WorldDiff(WorldDiff& other)
@@ -63,7 +63,7 @@ WorldDiff::WorldDiff(WorldDiff& other)
     changes_ = other.changes_;
 
     WorldWeakPtr(world).swap(world_);
-    observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, boost::placeholders::_1, boost::placeholders::_2));
+    observer_handle_ = world->addObserver(std::bind(&WorldDiff::notify, this, std::placeholders::_1, std::placeholders::_2));
   }
 }
 
@@ -87,7 +87,7 @@ void WorldDiff::reset(const WorldPtr& world)
     old_world->removeObserver(observer_handle_);
 
   WorldWeakPtr(world).swap(world_);
-  observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = world->addObserver(std::bind(&WorldDiff::notify, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 void WorldDiff::setWorld(const WorldPtr& world)
@@ -101,7 +101,7 @@ void WorldDiff::setWorld(const WorldPtr& world)
 
   WorldWeakPtr(world).swap(world_);
 
-  observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = world->addObserver(std::bind(&WorldDiff::notify, this, std::placeholders::_1, std::placeholders::_2));
   world->notifyObserverAllObjects(observer_handle_, World::CREATE | World::ADD_SHAPE);
 }
 

--- a/moveit_core/collision_detection/test/test_world.cpp
+++ b/moveit_core/collision_detection/test/test_world.cpp
@@ -236,7 +236,7 @@ TEST(World, TrackChanges)
 
   TestAction ta;
   collision_detection::World::ObserverHandle observer_ta;
-  observer_ta = world.addObserver(boost::bind(TrackChangesNotify, &ta, boost::placeholders::_1, boost::placeholders::_2));
+  observer_ta = world.addObserver(std::bind(TrackChangesNotify, &ta, std::placeholders::_1, std::placeholders::_2));
 
   // Create some shapes
   shapes::ShapePtr ball(new shapes::Sphere(1.0));
@@ -267,7 +267,7 @@ TEST(World, TrackChanges)
 
   TestAction ta2;
   collision_detection::World::ObserverHandle observer_ta2;
-  observer_ta2 = world.addObserver(boost::bind(TrackChangesNotify, &ta2, boost::placeholders::_1, boost::placeholders::_2));
+  observer_ta2 = world.addObserver(std::bind(TrackChangesNotify, &ta2, std::placeholders::_1, std::placeholders::_2));
 
   world.addToObject("obj2", cyl, Eigen::Isometry3d::Identity());
 
@@ -305,7 +305,7 @@ TEST(World, TrackChanges)
 
   TestAction ta3;
   collision_detection::World::ObserverHandle observer_ta3;
-  observer_ta3 = world.addObserver(boost::bind(TrackChangesNotify, &ta3, boost::placeholders::_1, boost::placeholders::_2));
+  observer_ta3 = world.addObserver(std::bind(TrackChangesNotify, &ta3, std::placeholders::_1, std::placeholders::_2));
 
   bool rm_good = world.removeShapeFromObject("obj2", cyl);
   EXPECT_TRUE(rm_good);

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -51,7 +51,7 @@ CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& m
   : CollisionEnv(model, padding, scale)
 {
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvBullet::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 
   for (const std::pair<const std::string, urdf::LinkSharedPtr>& link : robot_model_->getURDF()->links_)
   {
@@ -64,7 +64,7 @@ CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& m
   : CollisionEnv(model, world, padding, scale)
 {
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvBullet::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 
   for (const std::pair<const std::string, urdf::LinkSharedPtr>& link : robot_model_->getURDF()->links_)
   {
@@ -80,7 +80,7 @@ CollisionEnvBullet::CollisionEnvBullet(const CollisionEnvBullet& other, const Wo
   // TODO(j-petit): Verify this constructor
 
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvBullet::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 
   for (const std::pair<const std::string, urdf::LinkSharedPtr>& link : other.robot_model_->getURDF()->links_)
   {
@@ -294,7 +294,7 @@ void CollisionEnvBullet::setWorld(const WorldPtr& world)
   CollisionEnv::setWorld(world);
 
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvBullet::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 
   // get notifications any objects already in the new world
   getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -84,7 +84,7 @@ CollisionEnvFCL::CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, 
   manager_.reset(m);
 
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvFCL::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvFCL::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 CollisionEnvFCL::CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding,
@@ -121,7 +121,7 @@ CollisionEnvFCL::CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, 
   manager_.reset(m);
 
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvFCL::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvFCL::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
   getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
 }
 
@@ -145,7 +145,7 @@ CollisionEnvFCL::CollisionEnvFCL(const CollisionEnvFCL& other, const WorldPtr& w
   // manager_->update();
 
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvFCL::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvFCL::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 void CollisionEnvFCL::getAttachedBodyObjects(const moveit::core::AttachedBody* ab,
@@ -381,7 +381,7 @@ void CollisionEnvFCL::setWorld(const WorldPtr& world)
   CollisionEnv::setWorld(world);
 
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvFCL::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvFCL::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 
   // get notifications any objects already in the new world
   getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -67,7 +67,7 @@ CollisionEnvDistanceField::CollisionEnvDistanceField(
   distance_field_cache_entry_world_ = generateDistanceFieldCacheEntryWorld();
 
   // request notifications about changes to world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvDistanceField::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvDistanceField::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 CollisionEnvDistanceField::CollisionEnvDistanceField(
@@ -83,7 +83,7 @@ CollisionEnvDistanceField::CollisionEnvDistanceField(
   distance_field_cache_entry_world_ = generateDistanceFieldCacheEntryWorld();
 
   // request notifications about changes to world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvDistanceField::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvDistanceField::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 
   getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
 }
@@ -106,7 +106,7 @@ CollisionEnvDistanceField::CollisionEnvDistanceField(const CollisionEnvDistanceF
   planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
 
   // request notifications about changes to world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvDistanceField::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvDistanceField::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
   getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
 }
 
@@ -1681,7 +1681,7 @@ void CollisionEnvDistanceField::setWorld(const WorldPtr& world)
   CollisionEnv::setWorld(world);
 
   // request notifications about changes to new world
-  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvDistanceField::notifyObjectChange, this, boost::placeholders::_1, boost::placeholders::_2));
+  observer_handle_ = getWorld()->addObserver(std::bind(&CollisionEnvDistanceField::notifyObjectChange, this, std::placeholders::_1, std::placeholders::_2));
 
   // get notifications any objects already in the new world
   getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -543,7 +543,7 @@ bool IKConstraintSampler::sampleHelper(moveit::core::RobotState& state, const mo
   kinematics::KinematicsBase::IKCallbackFn adapted_ik_validity_callback;
   if (group_state_validity_callback_)
     adapted_ik_validity_callback =
-        boost::bind(&samplingIkCallbackFnAdapter, &state, jmg_, group_state_validity_callback_, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3);
+        std::bind(&samplingIkCallbackFnAdapter, &state, jmg_, group_state_validity_callback_, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 
   for (unsigned int a = 0; a < max_attempts; ++a)
   {

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -83,8 +83,8 @@ protected:
     pr2_kinematics_plugin_left_arm_->initialize(node_, *robot_model_, "left_arm", "torso_lift_link",
                                                 { "l_wrist_roll_link" }, .01);
 
-    func_right_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverRightArm, this, boost::placeholders::_1);
-    func_left_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverLeftArm, this, boost::placeholders::_1);
+    func_right_arm_ = std::bind(&LoadPlanningModelsPr2::getKinematicsSolverRightArm, this, std::placeholders::_1);
+    func_left_arm_ = std::bind(&LoadPlanningModelsPr2::getKinematicsSolverLeftArm, this, std::placeholders::_1);
 
     std::map<std::string, moveit::core::SolverAllocatorFn> allocators;
     allocators["right_arm"] = func_right_arm_;

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -66,7 +66,7 @@ bool PlanningRequestAdapter::adaptAndPlan(const planning_interface::PlannerManag
                                           planning_interface::MotionPlanResponse& res,
                                           std::vector<std::size_t>& added_path_index) const
 {
-  return adaptAndPlan(boost::bind(&callPlannerInterfaceSolve, planner.get(), boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3), planning_scene, req, res,
+  return adaptAndPlan(std::bind(&callPlannerInterfaceSolve, planner.get(), std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), planning_scene, req, res,
                       added_path_index);
 }
 
@@ -148,10 +148,10 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
 
     // if there are adapters, construct a function pointer for each, in order,
     // so that in the end we have a nested sequence of function pointers that call the adapters in the correct order.
-    PlanningRequestAdapter::PlannerFn fn = boost::bind(&callAdapter1, adapters_.back().get(), planner, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3,
+    PlanningRequestAdapter::PlannerFn fn = std::bind(&callAdapter1, adapters_.back().get(), planner, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                                                        boost::ref(added_path_index_each.back()));
     for (int i = adapters_.size() - 2; i >= 0; --i)
-      fn = boost::bind(&callAdapter2, adapters_[i].get(), fn, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::ref(added_path_index_each[i]));
+      fn = std::bind(&callAdapter2, adapters_[i].get(), fn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, boost::ref(added_path_index_each[i]));
     bool result = fn(planning_scene, req, res);
     added_path_index.clear();
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1729,7 +1729,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   // set callback function
   kinematics::KinematicsBase::IKCallbackFn ik_callback_fn;
   if (constraint)
-    ik_callback_fn = boost::bind(&ikCallbackFnAdapter, this, jmg, constraint, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3);
+    ik_callback_fn = std::bind(&ikCallbackFnAdapter, this, jmg, constraint, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 
   // Bijection
   const std::vector<unsigned int>& bij = jmg->getKinematicsSolverJointBijection();
@@ -1878,7 +1878,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   std::vector<geometry_msgs::msg::Pose> ik_queries(poses_in.size());
   kinematics::KinematicsBase::IKCallbackFn ik_callback_fn;
   if (constraint)
-    ik_callback_fn = boost::bind(&ikCallbackFnAdapter, this, jmg, constraint, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3);
+    ik_callback_fn = std::bind(&ikCallbackFnAdapter, this, jmg, constraint, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 
   for (std::size_t i = 0; i < transformed_poses.size(); ++i)
   {

--- a/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
+++ b/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
@@ -162,7 +162,7 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
       transformPoses(planning_scene, kinematic_state, request.pose_stamped_vector_, kinematic_model_->getModelFrame());
 
   moveit::core::StateValidityCallbackFn constraint_callback_fn =
-      boost::bind(&KinematicsConstraintAware::validityCallbackFn, this, planning_scene, request, response, boost::placeholders::_1, boost::placeholders::_2);
+      std::bind(&KinematicsConstraintAware::validityCallbackFn, this, planning_scene, request, response, std::placeholders::_1, std::placeholders::_2);
 
   bool result = false;
   if (has_sub_groups_)

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -619,7 +619,7 @@ TEST_F(KinematicsTest, randomWalkIK)
 //     }
 //
 //     kinematics_solver_->searchPositionIK(poses[0], fk_values, timeout_, solution,
-//                                          boost::bind(&KinematicsTest::searchIKCallback, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3),
+//                                          std::bind(&KinematicsTest::searchIKCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
 //                                          error_code);
 //     if (error_code.val == error_code.SUCCESS)
 //       success++;

--- a/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_meta_interface.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_meta_interface.cpp
@@ -58,9 +58,9 @@ bool SBPLMetaInterface::solve(const planning_scene::PlanningSceneConstPtr& plann
   PlanningParameters param_no_bfs;
   param_no_bfs.use_bfs_ = false;
   moveit_msgs::srv::GetMotionPlan::Response res1, res2;
-  boost::thread thread1(boost::bind(&SBPLMetaInterface::runSolver, this, true, boost::cref(planning_scene),
+  boost::thread thread1(std::bind(&SBPLMetaInterface::runSolver, this, true, boost::cref(planning_scene),
                                     boost::cref(req), boost::ref(res1), param_bfs));
-  boost::thread thread2(boost::bind(&SBPLMetaInterface::runSolver, this, false, boost::cref(planning_scene),
+  boost::thread thread2(std::bind(&SBPLMetaInterface::runSolver, this, false, boost::cref(planning_scene),
                                     boost::cref(req), boost::ref(res2), param_no_bfs));
   boost::mutex::scoped_lock lock(planner_done_mutex_);
   planner_done_condition_.wait(lock);

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -125,7 +125,7 @@ bool ThreadedController::sendTrajectory(const moveit_msgs::msg::RobotTrajectory&
   cancelTrajectory();  // cancel any previous fake motion
   cancel_ = false;
   status_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
-  thread_ = boost::thread(boost::bind(&ThreadedController::execTrajectory, this, t));
+  thread_ = boost::thread(std::bind(&ThreadedController::execTrajectory, this, t));
   return true;
 }
 

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -1279,7 +1279,7 @@ void moveit_benchmarks::BenchmarkExecution::runGoalExistenceBenchmark(BenchmarkR
     success = robot_state.setFromIK(
         robot_state.getJointModelGroup(req.motion_plan_request.group_name), ik_pose,
         req.motion_plan_request.num_planning_attempts, req.motion_plan_request.allowed_planning_time,
-        boost::bind(&isIKSolutionCollisionFree, planning_scene_.get(), boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, &reachable));
+        std::bind(&isIKSolutionCollisionFree, planning_scene_.get(), std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, &reachable));
     if (success)
     {
       ROS_INFO("  Success!");
@@ -1368,7 +1368,7 @@ void moveit_benchmarks::BenchmarkExecution::runGoalExistenceBenchmark(BenchmarkR
       success = robot_state.setFromIK(
           robot_state.getJointModelGroup(req.motion_plan_request.group_name), ik_pose,
           req.motion_plan_request.num_planning_attempts, req.motion_plan_request.allowed_planning_time,
-          boost::bind(&isIKSolutionCollisionFree, planning_scene_.get(), boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, &reachable));
+          std::bind(&isIKSolutionCollisionFree, planning_scene_.get(), std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, &reachable));
       double duration = (ros::WallTime::now() - startTime).toSec();
 
       if (success)

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -54,15 +54,15 @@ void move_group::MoveGroupPickPlaceAction::initialize()
 
   // start the pickup action server
   pickup_action_server_.reset(new actionlib::SimpleActionServer<moveit_msgs::action::PickupAction>(
-      root_node_handle_, PICKUP_ACTION, boost::bind(&MoveGroupPickPlaceAction::executePickupCallback, this, boost::placeholders::_1),
+      root_node_handle_, PICKUP_ACTION, std::bind(&MoveGroupPickPlaceAction::executePickupCallback, this, std::placeholders::_1),
       false));
-  pickup_action_server_->registerPreemptCallback(boost::bind(&MoveGroupPickPlaceAction::preemptPickupCallback, this));
+  pickup_action_server_->registerPreemptCallback(std::bind(&MoveGroupPickPlaceAction::preemptPickupCallback, this));
   pickup_action_server_->start();
 
   // start the place action server
   place_action_server_.reset(new actionlib::SimpleActionServer<moveit_msgs::action::PlaceAction>(
-      root_node_handle_, PLACE_ACTION, boost::bind(&MoveGroupPickPlaceAction::executePlaceCallback, this, boost::placeholders::_1), false));
-  place_action_server_->registerPreemptCallback(boost::bind(&MoveGroupPickPlaceAction::preemptPlaceCallback, this));
+      root_node_handle_, PLACE_ACTION, std::bind(&MoveGroupPickPlaceAction::executePlaceCallback, this, std::placeholders::_1), false));
+  place_action_server_->registerPreemptCallback(std::bind(&MoveGroupPickPlaceAction::preemptPlaceCallback, this));
   place_action_server_->start();
 }
 
@@ -260,17 +260,17 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallbackPlanAndExecute(
   opt.replan_ = goal->planning_options.replan;
   opt.replan_attempts_ = goal->planning_options.replan_attempts;
   opt.replan_delay_ = goal->planning_options.replan_delay;
-  opt.before_execution_callback_ = boost::bind(&MoveGroupPickPlaceAction::startPickupExecutionCallback, this);
+  opt.before_execution_callback_ = std::bind(&MoveGroupPickPlaceAction::startPickupExecutionCallback, this);
 
   opt.plan_callback_ =
-      boost::bind(&MoveGroupPickPlaceAction::planUsingPickPlacePickup, this, boost::cref(*goal), &action_res, boost::placeholders::_1);
+      std::bind(&MoveGroupPickPlaceAction::planUsingPickPlacePickup, this, boost::cref(*goal), &action_res, std::placeholders::_1);
   if (goal->planning_options.look_around && context_->plan_with_sensing_)
   {
-    opt.plan_callback_ = boost::bind(&plan_execution::PlanWithSensing::computePlan, context_->plan_with_sensing_.get(),
-                                     boost::placeholders::_1, opt.plan_callback_, goal->planning_options.look_around_attempts,
+    opt.plan_callback_ = std::bind(&plan_execution::PlanWithSensing::computePlan, context_->plan_with_sensing_.get(),
+                                     std::placeholders::_1, opt.plan_callback_, goal->planning_options.look_around_attempts,
                                      goal->planning_options.max_safe_execution_cost);
     context_->plan_with_sensing_->setBeforeLookCallback(
-        boost::bind(&MoveGroupPickPlaceAction::startPickupLookCallback, this));
+        std::bind(&MoveGroupPickPlaceAction::startPickupLookCallback, this));
   }
 
   plan_execution::ExecutableMotionPlan plan;
@@ -291,16 +291,16 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallbackPlanAndExecute(
   opt.replan_ = goal->planning_options.replan;
   opt.replan_attempts_ = goal->planning_options.replan_attempts;
   opt.replan_delay_ = goal->planning_options.replan_delay;
-  opt.before_execution_callback_ = boost::bind(&MoveGroupPickPlaceAction::startPlaceExecutionCallback, this);
+  opt.before_execution_callback_ = std::bind(&MoveGroupPickPlaceAction::startPlaceExecutionCallback, this);
   opt.plan_callback_ =
-      boost::bind(&MoveGroupPickPlaceAction::planUsingPickPlacePlace, this, boost::cref(*goal), &action_res, boost::placeholders::_1);
+      std::bind(&MoveGroupPickPlaceAction::planUsingPickPlacePlace, this, boost::cref(*goal), &action_res, std::placeholders::_1);
   if (goal->planning_options.look_around && context_->plan_with_sensing_)
   {
-    opt.plan_callback_ = boost::bind(&plan_execution::PlanWithSensing::computePlan, context_->plan_with_sensing_.get(),
-                                     boost::placeholders::_1, opt.plan_callback_, goal->planning_options.look_around_attempts,
+    opt.plan_callback_ = std::bind(&plan_execution::PlanWithSensing::computePlan, context_->plan_with_sensing_.get(),
+                                     std::placeholders::_1, opt.plan_callback_, goal->planning_options.look_around_attempts,
                                      goal->planning_options.max_safe_execution_cost);
     context_->plan_with_sensing_->setBeforeLookCallback(
-        boost::bind(&MoveGroupPickPlaceAction::startPlaceLookCallback, this));
+        std::bind(&MoveGroupPickPlaceAction::startPlaceLookCallback, this));
   }
 
   plan_execution::ExecutableMotionPlan plan;

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -181,7 +181,7 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
     plan_execution::ExecutableTrajectory et(ee_closed_traj, name);
 
     // Add a callback to attach the object to the EE after closing the gripper
-    et.effect_on_success_ = boost::bind(&executeAttachObject, plan->shared_data_, plan->approach_posture_, boost::placeholders::_1);
+    et.effect_on_success_ = std::bind(&executeAttachObject, plan->shared_data_, plan->approach_posture_, std::placeholders::_1);
     et.allowed_collision_matrix_ = collision_matrix;
     plan->trajectories_.push_back(et);
   }
@@ -225,8 +225,8 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
 
   // state validity checking during the approach must ensure that the gripper posture is that for pre-grasping
   moveit::core::GroupStateValidityCallbackFn approach_valid_callback =
-      boost::bind(&isStateCollisionFree, planning_scene_.get(), collision_matrix_.get(), verbose_,
-                  &plan->approach_posture_, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3);
+      std::bind(&isStateCollisionFree, planning_scene_.get(), collision_matrix_.get(), verbose_,
+                  &plan->approach_posture_, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
   plan->goal_sampler_->setVerbose(verbose_);
   std::size_t attempted_possible_goal_states = 0;
   do  // continously sample possible goal states
@@ -276,8 +276,8 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
           // state validity checking during the retreat after the grasp must ensure the gripper posture is that of the
           // actual grasp
           moveit::core::GroupStateValidityCallbackFn retreat_valid_callback =
-              boost::bind(&isStateCollisionFree, planning_scene_after_approach.get(), collision_matrix_.get(), verbose_,
-                          &plan->retreat_posture_, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3);
+              std::bind(&isStateCollisionFree, planning_scene_after_approach.get(), collision_matrix_.get(), verbose_,
+                          &plan->retreat_posture_, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 
           // try to compute a straight line path that moves from the goal in a desired direction
           moveit::core::RobotStatePtr last_retreat_state(

--- a/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
+++ b/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
@@ -114,7 +114,7 @@ void ManipulationPipeline::start()
     stage->resetStopSignal();
   for (std::size_t i = 0; i < processing_threads_.size(); ++i)
     if (!processing_threads_[i])
-      processing_threads_[i] = new boost::thread(boost::bind(&ManipulationPipeline::processingThread, this, i));
+      processing_threads_[i] = new boost::thread(std::bind(&ManipulationPipeline::processingThread, this, i));
 }
 
 void ManipulationPipeline::signalStop()

--- a/moveit_ros/manipulation/pick_place/src/pick_place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place.cpp
@@ -51,8 +51,8 @@ const double PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION = 7.0;  // sec
 PickPlacePlanBase::PickPlacePlanBase(const PickPlaceConstPtr& pick_place, const std::string& name)
   : pick_place_(pick_place), pipeline_(name, 4), last_plan_time_(0.0), done_(false)
 {
-  pipeline_.setSolutionCallback(boost::bind(&PickPlacePlanBase::foundSolution, this));
-  pipeline_.setEmptyQueueCallback(boost::bind(&PickPlacePlanBase::emptyQueue, this));
+  pipeline_.setSolutionCallback(std::bind(&PickPlacePlanBase::foundSolution, this));
+  pipeline_.setEmptyQueueCallback(std::bind(&PickPlacePlanBase::emptyQueue, this));
 }
 
 PickPlacePlanBase::~PickPlacePlanBase() = default;

--- a/moveit_ros/manipulation/pick_place/src/pick_place_params.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place_params.cpp
@@ -50,7 +50,7 @@ public:
   DynamicReconfigureImpl() : dynamic_reconfigure_server_(ros::NodeHandle("~/pick_place"))
   {
     dynamic_reconfigure_server_.setCallback(
-        boost::bind(&DynamicReconfigureImpl::dynamicReconfigureCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+        std::bind(&DynamicReconfigureImpl::dynamicReconfigureCallback, this, std::placeholders::_1, std::placeholders::_2));
   }
 
   const PickPlaceParams& getParams() const

--- a/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
+++ b/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
@@ -132,8 +132,8 @@ bool pick_place::ReachableAndValidPoseFilter::evaluate(const ManipulationPlanPtr
         constraints_sampler_manager_->selectSampler(planning_scene_, planning_group, plan->goal_constraints_);
     if (plan->goal_sampler_)
     {
-      plan->goal_sampler_->setGroupStateValidityCallback(boost::bind(
-          &isStateCollisionFree, planning_scene_.get(), collision_matrix_.get(), verbose_, plan.get(), boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+      plan->goal_sampler_->setGroupStateValidityCallback(std::bind(
+          &isStateCollisionFree, planning_scene_.get(), collision_matrix_.get(), verbose_, plan.get(), std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
       plan->goal_sampler_->setVerbose(verbose_);
       if (plan->goal_sampler_->sample(*token_state, plan->shared_data_->max_goal_sampling_attempts_))
       {

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -87,9 +87,9 @@ bool MoveGroupCartesianPathService::computeService(
     const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request> req,
     std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response> res)
 {
-  using boost::placeholders::_1;
-  using boost::placeholders::_2;
-  using boost::placeholders::_3;
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  using std::placeholders::_3;
 
   RCLCPP_INFO(LOGGER, "Received request to compute Cartesian path");
   context_->planning_scene_monitor_->updateFrameTransforms();
@@ -150,7 +150,7 @@ bool MoveGroupCartesianPathService::computeService(
             ls.reset(new planning_scene_monitor::LockedPlanningSceneRO(context_->planning_scene_monitor_));
             kset.reset(new kinematic_constraints::KinematicConstraintSet((*ls)->getRobotModel()));
             kset->add(req->path_constraints, (*ls)->getTransforms());
-            constraint_fn = boost::bind(
+            constraint_fn = std::bind(
                 &isStateValid,
                 req->avoid_collisions ? static_cast<const planning_scene::PlanningSceneConstPtr&>(*ls).get() : nullptr,
                 kset->empty() ? nullptr : kset.get(), _1, _2, _3);

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
@@ -61,7 +61,7 @@ void MoveGroupExecuteService::initialize()
   ros::AdvertiseServiceOptions ops;
   ops.template init<moveit_msgs::srv::ExecuteKnownTrajectory::Request,
                     moveit_msgs::srv::ExecuteKnownTrajectory::Response>(
-      EXECUTE_SERVICE_NAME, boost::bind(&MoveGroupExecuteService::executeTrajectoryService, this, boost::placeholders::_1, boost::placeholders::_2));
+      EXECUTE_SERVICE_NAME, std::bind(&MoveGroupExecuteService::executeTrajectoryService, this, std::placeholders::_1, std::placeholders::_2));
   ops.callback_queue = &callback_queue_;
   execute_service_ = root_node_handle_.advertiseService(ops);
   spinner_.start();

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -154,9 +154,9 @@ bool MoveGroupKinematicsService::computeIKService(const std::shared_ptr<rmw_requ
                                                   const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request> req,
                                                   std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response> res)
 {
-  using boost::placeholders::_1;
-  using boost::placeholders::_2;
-  using boost::placeholders::_3;
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  using std::placeholders::_3;
 
   context_->planning_scene_monitor_->updateFrameTransforms();
 
@@ -168,7 +168,7 @@ bool MoveGroupKinematicsService::computeIKService(const std::shared_ptr<rmw_requ
     moveit::core::RobotState rs = ls->getCurrentState();
     kset.add(req->ik_request.constraints, ls->getTransforms());
     computeIK(req->ik_request, res->solution, res->error_code, rs,
-              boost::bind(&isIKSolutionValid, req->ik_request.avoid_collisions ?
+              std::bind(&isIKSolutionValid, req->ik_request.avoid_collisions ?
                                                   static_cast<const planning_scene::PlanningSceneConstPtr&>(ls).get() :
                                                   nullptr,
                           kset.empty() ? nullptr : &kset, _1, _2, _3));

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -145,16 +145,16 @@ void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const std::shared_pt
   opt.replan_ = goal->get_goal()->planning_options.replan;
   opt.replan_attempts_ = goal->get_goal()->planning_options.replan_attempts;
   opt.replan_delay_ = goal->get_goal()->planning_options.replan_delay;
-  opt.before_execution_callback_ = boost::bind(&MoveGroupMoveAction::startMoveExecutionCallback, this);
+  opt.before_execution_callback_ = std::bind(&MoveGroupMoveAction::startMoveExecutionCallback, this);
 
   opt.plan_callback_ =
-      boost::bind(&MoveGroupMoveAction::planUsingPlanningPipeline, this, boost::cref(motion_plan_request), boost::placeholders::_1);
+      std::bind(&MoveGroupMoveAction::planUsingPlanningPipeline, this, boost::cref(motion_plan_request), std::placeholders::_1);
   if (goal->get_goal()->planning_options.look_around && context_->plan_with_sensing_)
   {
-    opt.plan_callback_ = boost::bind(&plan_execution::PlanWithSensing::computePlan, context_->plan_with_sensing_.get(),
-                                     boost::placeholders::_1, opt.plan_callback_, goal->get_goal()->planning_options.look_around_attempts,
+    opt.plan_callback_ = std::bind(&plan_execution::PlanWithSensing::computePlan, context_->plan_with_sensing_.get(),
+                                     std::placeholders::_1, opt.plan_callback_, goal->get_goal()->planning_options.look_around_attempts,
                                      goal->get_goal()->planning_options.max_safe_execution_cost);
-    context_->plan_with_sensing_->setBeforeLookCallback(boost::bind(&MoveGroupMoveAction::startMoveLookCallback, this));
+    context_->plan_with_sensing_->setBeforeLookCallback(std::bind(&MoveGroupMoveAction::startMoveLookCallback, this));
   }
 
   plan_execution::ExecutableMotionPlan plan;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -202,13 +202,13 @@ void OccupancyMapMonitor::addUpdater(const OccupancyMapUpdaterPtr& updater)
       if (map_updaters_.size() == 2)
       {
         map_updaters_[0]->setTransformCacheCallback(
-            boost::bind(&OccupancyMapMonitor::getShapeTransformCache, this, 0, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+            std::bind(&OccupancyMapMonitor::getShapeTransformCache, this, 0, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         map_updaters_[1]->setTransformCacheCallback(
-            boost::bind(&OccupancyMapMonitor::getShapeTransformCache, this, 1, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+            std::bind(&OccupancyMapMonitor::getShapeTransformCache, this, 1, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
       }
       else
         map_updaters_.back()->setTransformCacheCallback(
-            boost::bind(&OccupancyMapMonitor::getShapeTransformCache, this, map_updaters_.size() - 1, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+            std::bind(&OccupancyMapMonitor::getShapeTransformCache, this, map_updaters_.size() - 1, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     }
     else
       updater->setTransformCacheCallback(transform_cache_callback_);

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
   std::shared_ptr<tf2_ros::Buffer> buffer = std::make_shared<tf2_ros::Buffer>(clock_ptr, tf2::durationFromSec(5.0));
   std::shared_ptr<tf2_ros::TransformListener> listener = std::make_shared<tf2_ros::TransformListener>(*buffer, node);
   occupancy_map_monitor::OccupancyMapMonitor server(node, buffer);
-  server.setUpdateCallback(boost::bind(&publishOctomap, octree_binary_pub, &server));
+  server.setUpdateCallback(std::bind(&publishOctomap, octree_binary_pub, &server));
   server.startMonitor();
 
   rclcpp::spin(node);

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -127,7 +127,7 @@ bool DepthImageOctomapUpdater::initialize()
   mesh_filter_->setShadowThreshold(shadow_threshold_);
   mesh_filter_->setPaddingOffset(padding_offset_);
   mesh_filter_->setPaddingScale(padding_scale_);
-  mesh_filter_->setTransformCallback(boost::bind(&DepthImageOctomapUpdater::getShapeTransform, this, boost::placeholders::_1, boost::placeholders::_2));
+  mesh_filter_->setTransformCallback(std::bind(&DepthImageOctomapUpdater::getShapeTransform, this, std::placeholders::_1, std::placeholders::_2));
 
   return true;
 }

--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -48,8 +48,8 @@ LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const OccMapTreePtr& tree, unsigned i
   , max_sensor_delta_(1e-3)  // 1mm
   , process_occupied_cells_set_(nullptr)
   , process_model_cells_set_(nullptr)
-  , update_thread_(boost::bind(&LazyFreeSpaceUpdater::lazyUpdateThread, this))
-  , process_thread_(boost::bind(&LazyFreeSpaceUpdater::processThread, this))
+  , update_thread_(std::bind(&LazyFreeSpaceUpdater::lazyUpdateThread, this))
+  , process_thread_(std::bind(&LazyFreeSpaceUpdater::processThread, this))
 {
 }
 

--- a/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
+++ b/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
@@ -118,7 +118,7 @@ MeshFilterTest<Type>::MeshFilterTest(unsigned width, unsigned height, double nea
   , shadow_(shadow)
   , epsilon_(epsilon)
   , sensor_parameters_(width, height, near_, far_, width >> 1, height >> 1, width >> 1, height >> 1, 0.1, 0.1)
-  , filter_(boost::bind(&MeshFilterTest<Type>::transformCallback, this, boost::placeholders::_1, boost::placeholders::_2), sensor_parameters_)
+  , filter_(std::bind(&MeshFilterTest<Type>::transformCallback, this, std::placeholders::_1, std::placeholders::_2), sensor_parameters_)
   , sensor_data_(width_ * height_)
   , distance_(0.0)
 {

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -97,7 +97,7 @@ bool PointCloudOctomapUpdater::initialize()
   tf_buffer_.reset(new tf2_ros::Buffer());
   tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_, root_nh_));
   shape_mask_.reset(new point_containment_filter::ShapeMask());
-  shape_mask_->setTransformCallback(boost::bind(&PointCloudOctomapUpdater::getShapeTransform, this, boost::placeholders::_1, boost::placeholders::_2));
+  shape_mask_->setTransformCallback(std::bind(&PointCloudOctomapUpdater::getShapeTransform, this, std::placeholders::_1, std::placeholders::_2));
   if (!filtered_cloud_topic_.empty())
     filtered_cloud_publisher_ = private_nh_.advertise<sensor_msgs::PointCloud2>(filtered_cloud_topic_, 10, false);
   return true;
@@ -113,13 +113,13 @@ void PointCloudOctomapUpdater::start()
   {
     point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::PointCloud2>(*point_cloud_subscriber_, *tf_buffer_,
                                                                                monitor_->getMapFrame(), 5, root_nh_);
-    point_cloud_filter_->registerCallback(boost::bind(&PointCloudOctomapUpdater::cloudMsgCallback, this, boost::placeholders::_1));
+    point_cloud_filter_->registerCallback(std::bind(&PointCloudOctomapUpdater::cloudMsgCallback, this, std::placeholders::_1));
     ROS_INFO_NAMED(LOGNAME, "Listening to '%s' using message filter with target frame '%s'", point_cloud_topic_.c_str(),
                    point_cloud_filter_->getTargetFramesString().c_str());
   }
   else
   {
-    point_cloud_subscriber_->registerCallback(boost::bind(&PointCloudOctomapUpdater::cloudMsgCallback, this, boost::placeholders::_1));
+    point_cloud_subscriber_->registerCallback(std::bind(&PointCloudOctomapUpdater::cloudMsgCallback, this, std::placeholders::_1));
     ROS_INFO_NAMED(LOGNAME, "Listening to '%s'", point_cloud_topic_.c_str());
   }
 }

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -260,7 +260,7 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction()
   moveit::tools::Profiler::ScopedBlock prof_block("KinematicsPluginLoader::getLoaderFunction");
 
   if (loader_)
-    return boost::bind(&KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(),  boost::placeholders::_1);
+    return std::bind(&KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(),  std::placeholders::_1);
 
   rdf_loader::RDFLoader rml(node_, robot_description_);
   robot_description_ = rml.getRobotDescription();
@@ -417,6 +417,6 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const 
                                            iksolver_to_tip_links));
   }
 
-  return boost::bind(&KinematicsPluginLoader::KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(),  boost::placeholders::_1);
+  return std::bind(&KinematicsPluginLoader::KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(),  std::placeholders::_1);
 }
 }  // namespace kinematics_plugin_loader

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -56,7 +56,7 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.plan_executi
 //     : owner_(owner)  //, dynamic_reconfigure_server_(ros::NodeHandle("~/plan_execution"))
 //   {
 //     // dynamic_reconfigure_server_.setCallback(
-//     //     boost::bind(&DynamicReconfigureImpl::dynamicReconfigureCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+//     //     std::bind(&DynamicReconfigureImpl::dynamicReconfigureCallback, this, std::placeholders::_1, std::placeholders::_2));
 //   }
 //
 // private:
@@ -86,7 +86,7 @@ plan_execution::PlanExecution::PlanExecution(
   new_scene_update_ = false;
 
   // we want to be notified when new information is available
-  planning_scene_monitor_->addUpdateCallback(boost::bind(&PlanExecution::planningSceneUpdatedCallback, this, boost::placeholders::_1));
+  planning_scene_monitor_->addUpdateCallback(std::bind(&PlanExecution::planningSceneUpdatedCallback, this, std::placeholders::_1));
 
   // start the dynamic-reconfigure server
   // reconfigure_impl_ = new DynamicReconfigureImpl(this);
@@ -402,8 +402,8 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
 
   // start a trajectory execution thread
   trajectory_execution_manager_->execute(
-      boost::bind(&PlanExecution::doneWithTrajectoryExecution, this, boost::placeholders::_1),
-      boost::bind(&PlanExecution::successfulTrajectorySegmentExecution, this, &plan, boost::placeholders::_1));
+      std::bind(&PlanExecution::doneWithTrajectoryExecution, this, std::placeholders::_1),
+      std::bind(&PlanExecution::successfulTrajectorySegmentExecution, this, &plan, std::placeholders::_1));
   // wait for path to be done, while checking that the path does not become invalid
   rclcpp::WallRate r(100);
   path_became_invalid_ = false;

--- a/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
@@ -56,7 +56,7 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.plan_with_se
 //     : owner_(owner) /*, dynamic_reconfigure_server_(ros::NodeHandle("~/sense_for_plan"))*/
 //   {
 //     // dynamic_reconfigure_server_.setCallback(
-//     //     boost::bind(&DynamicReconfigureImpl::dynamicReconfigureCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+//     //     std::bind(&DynamicReconfigureImpl::dynamicReconfigureCallback, this, std::placeholders::_1, std::placeholders::_2));
 //   }
 //
 // private:

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
     runCollisionDetection(10, trials, psm.getPlanningScene().get(), states[0].get());
     for (unsigned int i = 0; i < states.size(); ++i)
       threads.push_back(new boost::thread(
-          boost::bind(&runCollisionDetection, i, trials, psm.getPlanningScene().get(), states[i].get())));
+          std::bind(&runCollisionDetection, i, trials, psm.getPlanningScene().get(), states[i].get())));
 
     for (unsigned int i = 0; i < states.size(); ++i)
     {

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -184,9 +184,9 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     if (scene_)
     {
       scene_->setAttachedBodyUpdateCallback(
-          boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+          std::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
       scene_->setCollisionObjectUpdateCallback(
-          boost::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+          std::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
     }
   }
   else
@@ -322,9 +322,9 @@ void PlanningSceneMonitor::monitorDiffs(bool flag)
         scene_ = parent_scene_->diff();
         scene_const_ = scene_;
         scene_->setAttachedBodyUpdateCallback(
-            boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+            std::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
         scene_->setCollisionObjectUpdateCallback(
-            boost::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+            std::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
       }
     }
     else
@@ -376,7 +376,7 @@ void PlanningSceneMonitor::startPublishingPlanningScene(SceneUpdateType update_t
     planning_scene_publisher_ = pnode_->create_publisher<moveit_msgs::msg::PlanningScene>(planning_scene_topic, 100);
     RCLCPP_INFO(LOGGER, "Publishing maintained planning scene on '%s'", planning_scene_topic.c_str());
     monitorDiffs(true);
-    publish_planning_scene_.reset(new boost::thread(boost::bind(&PlanningSceneMonitor::scenePublishingThread, this)));
+    publish_planning_scene_.reset(new boost::thread(std::bind(&PlanningSceneMonitor::scenePublishingThread, this)));
   }
 }
 
@@ -435,9 +435,9 @@ void PlanningSceneMonitor::scenePublishingThread()
           scene_->pushDiffs(parent_scene_);
           scene_->clearDiffs();
           scene_->setAttachedBodyUpdateCallback(
-              boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+              std::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
           scene_->setCollisionObjectUpdateCallback(
-              boost::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+              std::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
           if (octomap_monitor_)
           {
             excludeAttachedBodiesFromOctree();  // in case updates have happened to the attached bodies, put them in
@@ -667,9 +667,9 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
       scene_ = parent_scene_->diff();
       scene_const_ = scene_;
       scene_->setAttachedBodyUpdateCallback(
-          boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+          std::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
       scene_->setCollisionObjectUpdateCallback(
-          boost::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+          std::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, std::placeholders::_1, std::placeholders::_2));
     }
     if (octomap_monitor_)
     {
@@ -1174,8 +1174,8 @@ void PlanningSceneMonitor::startWorldGeometryMonitor(const std::string& collisio
       excludeWorldObjectsFromOctree();
 
       octomap_monitor_->setTransformCacheCallback(
-          boost::bind(&PlanningSceneMonitor::getShapeTransformCache, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
-      octomap_monitor_->setUpdateCallback(boost::bind(&PlanningSceneMonitor::octomapUpdateCallback, this));
+          std::bind(&PlanningSceneMonitor::getShapeTransformCache, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      octomap_monitor_->setUpdateCallback(std::bind(&PlanningSceneMonitor::octomapUpdateCallback, this));
     }
     octomap_monitor_->startMonitor();
   }
@@ -1207,7 +1207,7 @@ void PlanningSceneMonitor::startStateMonitor(const std::string& joint_states_top
     {
       current_state_monitor_.reset(new CurrentStateMonitor(pnode_, getRobotModel(), tf_buffer_));
     }
-    current_state_monitor_->addUpdateCallback(boost::bind(&PlanningSceneMonitor::onStateUpdate, this, boost::placeholders::_1));
+    current_state_monitor_->addUpdateCallback(std::bind(&PlanningSceneMonitor::onStateUpdate, this, std::placeholders::_1));
     current_state_monitor_->startStateMonitor(joint_states_topic);
 
     {

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -77,7 +77,7 @@ void planning_scene_monitor::TrajectoryMonitor::startTrajectoryMonitor()
 {
   if (sampling_frequency_ > std::numeric_limits<double>::epsilon() && !record_states_thread_)
   {
-    record_states_thread_.reset(new boost::thread(boost::bind(&TrajectoryMonitor::recordStates, this)));
+    record_states_thread_.reset(new boost::thread(std::bind(&TrajectoryMonitor::recordStates, this)));
     RCLCPP_DEBUG(LOGGER, "Started trajectory monitor");
   }
 }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -387,7 +387,7 @@ bool TrajectoryExecutionManager::pushAndExecute(const moveit_msgs::msg::RobotTra
       continuous_execution_queue_.push_back(context);
       if (!continuous_execution_thread_)
         continuous_execution_thread_.reset(
-            new boost::thread(boost::bind(&TrajectoryExecutionManager::continuousExecutionThread, this)));
+            new boost::thread(std::bind(&TrajectoryExecutionManager::continuousExecutionThread, this)));
     }
     last_execution_status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
     continuous_execution_condition_.notify_all();

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1267,7 +1267,7 @@ public:
     if (constraints_init_thread_)
       constraints_init_thread_->join();
     constraints_init_thread_.reset(
-        new boost::thread(boost::bind(&MoveGroupInterfaceImpl::initializeConstraintsStorageThread, this, host, port)));
+        new boost::thread(std::bind(&MoveGroupInterfaceImpl::initializeConstraintsStorageThread, this, host, port)));
   }
 
   void setWorkspace(double minx, double miny, double minz, double maxx, double maxy, double maxz)

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -210,7 +210,7 @@ void InteractionHandler::handleGeneric(
     StateChangeCallbackFn callback;
     // modify the RobotState in-place with the state_lock_ held.
     LockedRobotState::modifyState(
-        boost::bind(&InteractionHandler::updateStateGeneric, this, boost::placeholders::_1, &g, &feedback, &callback));
+        std::bind(&InteractionHandler::updateStateGeneric, this, std::placeholders::_1, &g, &feedback, &callback));
 
     // This calls update_callback_ to notify client that state changed.
     if (callback)
@@ -243,7 +243,7 @@ void InteractionHandler::handleEndEffector(
   // modify the RobotState in-place with state_lock_ held.
   // This locks state_lock_ before calling updateState()
   LockedRobotState::modifyState(
-      boost::bind(&InteractionHandler::updateStateEndEffector, this, boost::placeholders::_1, &eef, &tpose.pose, &callback));
+      std::bind(&InteractionHandler::updateStateEndEffector, this, std::placeholders::_1, &eef, &tpose.pose, &callback));
 
   // This calls update_callback_ to notify client that state changed.
   if (callback)
@@ -274,7 +274,7 @@ void InteractionHandler::handleJoint(const JointInteraction& vj,
   // modify the RobotState in-place with state_lock_ held.
   // This locks state_lock_ before calling updateState()
   LockedRobotState::modifyState(
-      boost::bind(&InteractionHandler::updateStateJoint, this, boost::placeholders::_1, &vj, &tpose.pose, &callback));
+      std::bind(&InteractionHandler::updateStateJoint, this, std::placeholders::_1, &vj, &tpose.pose, &callback));
 
   // This calls update_callback_ to notify client that state changed.
   if (callback)
@@ -289,7 +289,7 @@ void InteractionHandler::updateStateGeneric(
   bool ok = g->process_feedback(*state, *feedback);
   bool error_state_changed = setErrorState(g->marker_name_suffix, !ok);
   if (update_callback_)
-    *callback = boost::bind(update_callback_, boost::placeholders::_1, error_state_changed);
+    *callback = std::bind(update_callback_, std::placeholders::_1, error_state_changed);
 }
 
 // MUST hold state_lock_ when calling this!
@@ -303,7 +303,7 @@ void InteractionHandler::updateStateEndEffector(moveit::core::RobotState* state,
   bool ok = kinematic_options.setStateFromIK(*state, eef->parent_group, eef->parent_link, *pose);
   bool error_state_changed = setErrorState(eef->parent_group, !ok);
   if (update_callback_)
-    *callback = boost::bind(update_callback_, boost::placeholders::_1, error_state_changed);
+    *callback = std::bind(update_callback_, std::placeholders::_1, error_state_changed);
 }
 
 // MUST hold state_lock_ when calling this!
@@ -321,7 +321,7 @@ void InteractionHandler::updateStateJoint(moveit::core::RobotState* state, const
   state->update();
 
   if (update_callback_)
-    *callback = boost::bind(update_callback_, boost::placeholders::_1, false);
+    *callback = std::bind(update_callback_, std::placeholders::_1, false);
 }
 
 bool InteractionHandler::inError(const EndEffectorInteraction& eef) const

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -73,7 +73,7 @@ RobotInteraction::RobotInteraction(const moveit::core::RobotModelConstPtr& robot
 
   // spin a thread that will process feedback events
   run_processing_thread_ = true;
-  processing_thread_.reset(new boost::thread(boost::bind(&RobotInteraction::processingThread, this)));
+  processing_thread_.reset(new boost::thread(std::bind(&RobotInteraction::processingThread, this)));
 }
 
 RobotInteraction::~RobotInteraction()
@@ -543,7 +543,7 @@ void RobotInteraction::addInteractiveMarkers(const InteractionHandlerPtr& handle
   {
     int_marker_server_->insert(im);
     int_marker_server_->setCallback(im.name,
-                                    boost::bind(&RobotInteraction::processInteractiveMarkerFeedback, this, boost::placeholders::_1));
+                                    std::bind(&RobotInteraction::processInteractiveMarkerFeedback, this, std::placeholders::_1));
 
     // Add menu handler to all markers that this interaction handler creates.
     if (std::shared_ptr<interactive_markers::MenuHandler> mh = handler->getMenuHandler())

--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -433,7 +433,7 @@ void MyInfo::modifyThreadFunc(robot_interaction::LockedRobotState* locked_state,
     {
       val += 0.0001;
 
-      locked_state->modifyState(boost::bind(&MyInfo::modifyFunc, this, boost::placeholders::_1, val));
+      locked_state->modifyState(std::bind(&MyInfo::modifyFunc, this, std::placeholders::_1, val));
     }
 
     cnt_lock_.lock();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -177,7 +177,7 @@ MotionPlanningDisplay::MotionPlanningDisplay()
   trajectory_visual_.reset(new TrajectoryVisualization(path_category_, this));
 
   // Start background jobs
-  background_process_.setJobUpdateEvent(boost::bind(&MotionPlanningDisplay::backgroundJobUpdate, this, boost::placeholders::_1, boost::placeholders::_2));
+  background_process_.setJobUpdateEvent(std::bind(&MotionPlanningDisplay::backgroundJobUpdate, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 // ******************************************************************************************
@@ -289,7 +289,7 @@ void MotionPlanningDisplay::toggleSelectPlanningGroupSubscription(bool enable)
 void MotionPlanningDisplay::selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr msg)
 {
   // synchronize ROS callback with main loop
-  addMainLoopJob(boost::bind(&MotionPlanningDisplay::changePlanningGroup, this, msg->data));
+  addMainLoopJob(std::bind(&MotionPlanningDisplay::changePlanningGroup, this, msg->data));
 }
 
 void MotionPlanningDisplay::reset()
@@ -314,7 +314,7 @@ void MotionPlanningDisplay::reset()
 void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent /*unused*/,
                                                 const std::string& /*unused*/)
 {
-  addMainLoopJob(boost::bind(&MotionPlanningDisplay::updateBackgroundJobProgressBar, this));
+  addMainLoopJob(std::bind(&MotionPlanningDisplay::updateBackgroundJobProgressBar, this));
 }
 
 void MotionPlanningDisplay::updateBackgroundJobProgressBar()
@@ -712,7 +712,7 @@ void MotionPlanningDisplay::changedQueryStartState()
   setStatusTextColor(query_start_color_property_->getColor());
   addStatusText("Changed start state");
   drawQueryStartState();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true),
+  addBackgroundJob(std::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true),
                    "publishInteractiveMarkers");
 }
 
@@ -723,7 +723,7 @@ void MotionPlanningDisplay::changedQueryGoalState()
   setStatusTextColor(query_goal_color_property_->getColor());
   addStatusText("Changed goal state");
   drawQueryGoalState();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true),
+  addBackgroundJob(std::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true),
                    "publishInteractiveMarkers");
 }
 
@@ -796,7 +796,7 @@ void MotionPlanningDisplay::resetInteractiveMarkers()
 {
   query_start_state_->clearError();
   query_goal_state_->clearError();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false),
+  addBackgroundJob(std::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false),
                    "publishInteractiveMarkers");
 }
 
@@ -902,7 +902,7 @@ void MotionPlanningDisplay::scheduleDrawQueryStartState(robot_interaction::Inter
 {
   if (!planning_scene_monitor_)
     return;
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, !error_state_changed),
+  addBackgroundJob(std::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, !error_state_changed),
                    "publishInteractiveMarkers");
   updateQueryStartState();
 }
@@ -912,7 +912,7 @@ void MotionPlanningDisplay::scheduleDrawQueryGoalState(robot_interaction::Intera
 {
   if (!planning_scene_monitor_)
     return;
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, !error_state_changed),
+  addBackgroundJob(std::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, !error_state_changed),
                    "publishInteractiveMarkers");
   updateQueryGoalState();
 }
@@ -921,7 +921,7 @@ void MotionPlanningDisplay::updateQueryStartState()
 {
   queryStartStateChanged();
   recomputeQueryStartStateMetrics();
-  addMainLoopJob(boost::bind(&MotionPlanningDisplay::changedQueryStartState, this));
+  addMainLoopJob(std::bind(&MotionPlanningDisplay::changedQueryStartState, this));
   context_->queueRender();
 }
 
@@ -929,7 +929,7 @@ void MotionPlanningDisplay::updateQueryGoalState()
 {
   queryGoalStateChanged();
   recomputeQueryGoalStateMetrics();
-  addMainLoopJob(boost::bind(&MotionPlanningDisplay::changedQueryGoalState, this));
+  addMainLoopJob(std::bind(&MotionPlanningDisplay::changedQueryGoalState, this));
   context_->queueRender();
 }
 
@@ -1039,7 +1039,7 @@ void MotionPlanningDisplay::changedPlanningGroup()
 
   if (frame_)
     frame_->changePlanningGroup();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false),
+  addBackgroundJob(std::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false),
                    "publishInteractiveMarkers");
 }
 
@@ -1109,7 +1109,7 @@ void MotionPlanningDisplay::populateMenuHandler(std::shared_ptr<interactive_mark
     if ((state_name == "same as start" && is_start) || (state_name == "same as goal" && !is_start))
       continue;
     mh->insert(menu_states, state_name,
-               boost::bind(&MotionPlanningDisplay::setQueryStateHelper, this, is_start, state_name));
+               std::bind(&MotionPlanningDisplay::setQueryStateHelper, this, is_start, state_name));
   }
 
   //  // Group commands, which end up being the same for both interaction handlers
@@ -1117,7 +1117,7 @@ void MotionPlanningDisplay::populateMenuHandler(std::shared_ptr<interactive_mark
   //  immh::EntryHandle menu_groups = mh->insert("Planning Group", immh::FeedbackCallback());
   //  for (int i = 0; i < group_names.size(); ++i)
   //    mh->insert(menu_groups, group_names[i],
-  //               boost::bind(&MotionPlanningDisplay::changePlanningGroup, this, group_names[i]));
+  //               std::bind(&MotionPlanningDisplay::changePlanningGroup, this, group_names[i]));
 }
 
 void MotionPlanningDisplay::onRobotModelLoaded()
@@ -1128,7 +1128,7 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   robot_interaction_.reset(
       new robot_interaction::RobotInteraction(getRobotModel(), node_, "rviz_moveit_motion_planning_display"));
   robot_interaction::KinematicOptions o;
-  o.state_validity_callback_ = boost::bind(&MotionPlanningDisplay::isIKSolutionCollisionFree, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3);
+  o.state_validity_callback_ = std::bind(&MotionPlanningDisplay::isIKSolutionCollisionFree, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
   robot_interaction_->getKinematicOptionsMap()->setOptions(
       robot_interaction::KinematicOptionsMap::ALL, o, robot_interaction::KinematicOptions::STATE_VALIDITY_CALLBACK);
 
@@ -1143,8 +1143,8 @@ void MotionPlanningDisplay::onRobotModelLoaded()
                                                                      planning_scene_monitor_->getTFClient()));
   query_goal_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "goal", *previous_state_,
                                                                     planning_scene_monitor_->getTFClient()));
-  query_start_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryStartState, this, boost::placeholders::_1, boost::placeholders::_2));
-  query_goal_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryGoalState, this, boost::placeholders::_1, boost::placeholders::_2));
+  query_start_state_->setUpdateCallback(std::bind(&MotionPlanningDisplay::scheduleDrawQueryStartState, this, std::placeholders::_1, std::placeholders::_2));
+  query_goal_state_->setUpdateCallback(std::bind(&MotionPlanningDisplay::scheduleDrawQueryGoalState, this, std::placeholders::_1, std::placeholders::_2));
 
   // Interactive marker menus
   populateMenuHandler(menu_handler_start_);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -234,7 +234,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz_c
   //      semantic_world_.reset();
   //    if (semantic_world_)
   //    {
-  //      semantic_world_->addTableCallback(boost::bind(&MotionPlanningFrame::updateTables, this));
+  //      semantic_world_->addTableCallback(std::bind(&MotionPlanningFrame::updateTables, this));
   //    }
   //  }
   //  catch (std::exception& ex)
@@ -363,14 +363,14 @@ void MotionPlanningFrame::changePlanningGroupHelper()
   if (!planning_display_->getPlanningSceneMonitor())
     return;
 
-  planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::fillStateSelectionOptions, this));
+  planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::fillStateSelectionOptions, this));
   planning_display_->addMainLoopJob(
-      boost::bind(&MotionPlanningFrame::populateConstraintsList, this, std::vector<std::string>()));
+      std::bind(&MotionPlanningFrame::populateConstraintsList, this, std::vector<std::string>()));
 
   const moveit::core::RobotModelConstPtr& robot_model = planning_display_->getRobotModel();
   std::string group = planning_display_->getCurrentPlanningGroup();
   planning_display_->addMainLoopJob(
-      boost::bind(&MotionPlanningParamWidget::setGroupName, ui_->planner_param_treeview, group));
+      std::bind(&MotionPlanningParamWidget::setGroupName, ui_->planner_param_treeview, group));
   planning_display_->addMainLoopJob(
       [=]() { ui_->planning_group_combo_box->setCurrentText(QString::fromStdString(group)); });
 
@@ -405,7 +405,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
       RCLCPP_ERROR(LOGGER, "%s", ex.what());
     }
     planning_display_->addMainLoopJob(
-        boost::bind(&MotionPlanningParamWidget::setMoveGroup, ui_->planner_param_treeview, move_group_));
+        std::bind(&MotionPlanningParamWidget::setMoveGroup, ui_->planner_param_treeview, move_group_));
     if (move_group_)
     {
       move_group_->allowLooking(ui_->allow_looking->isChecked());
@@ -414,8 +414,8 @@ void MotionPlanningFrame::changePlanningGroupHelper()
       planning_display_->addMainLoopJob([=]() { ui_->use_cartesian_path->setEnabled(has_unique_endeffector); });
       moveit_msgs::msg::PlannerInterfaceDescription desc;
       if (move_group_->getInterfaceDescription(desc))
-        planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlannersList, this, desc));
-      planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::populateConstraintsList, this),
+        planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populatePlannersList, this, desc));
+      planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::populateConstraintsList, this),
                                           "populateConstraintsList");
 
       if (first_time_)
@@ -431,7 +431,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
         planning_display_->useApproximateIK(ui_->approximate_ik->isChecked());
         if (ui_->allow_external_program->isChecked())
           planning_display_->addMainLoopJob(
-              boost::bind(&MotionPlanningFrame::allowExternalProgramCommunication, this, true));
+              std::bind(&MotionPlanningFrame::allowExternalProgramCommunication, this, true));
       }
     }
   }
@@ -439,7 +439,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
 
 void MotionPlanningFrame::changePlanningGroup()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::changePlanningGroupHelper, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::changePlanningGroupHelper, this),
                                       "Frame::changePlanningGroup");
   joints_tab_->changePlanningGroup(planning_display_->getCurrentPlanningGroup(),
                                    planning_display_->getQueryStartStateHandler(),
@@ -449,7 +449,7 @@ void MotionPlanningFrame::changePlanningGroup()
 void MotionPlanningFrame::sceneUpdate(planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type)
 {
   if (update_type & planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY)
-    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+    planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
 }
 
 void MotionPlanningFrame::addSceneObject()
@@ -526,11 +526,11 @@ void MotionPlanningFrame::addSceneObject()
   }
   setLocalSceneEdited();
 
-  planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+  planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
 
   // Automatically select the inserted object so that its IM is displayed
   planning_display_->addMainLoopJob(
-      boost::bind(&MotionPlanningFrame::setItemSelectionInList, this, shape_name, true, ui_->collision_objects_list));
+      std::bind(&MotionPlanningFrame::setItemSelectionInList, this, shape_name, true, ui_->collision_objects_list));
 
   planning_display_->queueRenderSceneGeometry();
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
@@ -54,7 +54,7 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualizatio
 
 void MotionPlanningFrame::databaseConnectButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClicked, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClicked, this),
                                       "connect to database");
 }
 
@@ -94,7 +94,7 @@ void MotionPlanningFrame::resetDbButtonClicked()
     return;
 
   planning_display_->addBackgroundJob(
-      boost::bind(&MotionPlanningFrame::computeResetDbButtonClicked, this, response.toStdString()), "reset database");
+      std::bind(&MotionPlanningFrame::computeResetDbButtonClicked, this, response.toStdString()), "reset database");
 }
 
 void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
@@ -107,12 +107,12 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
   //    robot_state_storage_.reset();
   //    constraints_storage_.reset();
   //    planning_display_->addMainLoopJob(
-  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 1));
+  //        std::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 1));
   //  }
   //  else
   //  {
   //    planning_display_->addMainLoopJob(
-  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 2));
+  //        std::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 2));
   //    try
   //    {
   //      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
@@ -126,19 +126,19 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
   //      else
   //      {
   //        planning_display_->addMainLoopJob(
-  //            boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
+  //            std::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
   //        return;
   //      }
   //    }
   //    catch (std::exception& ex)
   //    {
   //      planning_display_->addMainLoopJob(
-  //          boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
+  //          std::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
   //      ROS_ERROR("%s", ex.what());
   //      return;
   //    }
   //    planning_display_->addMainLoopJob(
-  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 4));
+  //        std::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 4));
   //  }
 }
 
@@ -192,7 +192,7 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper(int mode)
     if (move_group_)
     {
       move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
-      planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::populateConstraintsList, this),
+      planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::populateConstraintsList, this),
                                           "populateConstraintsList");
     }
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -62,10 +62,10 @@ void MotionPlanningFrame::detectObjectsButtonClicked()
   //    }
   //    if (semantic_world_)
   //    {
-  //      semantic_world_->addTableCallback(boost::bind(&MotionPlanningFrame::updateTables, this));
+  //      semantic_world_->addTableCallback(std::bind(&MotionPlanningFrame::updateTables, this));
   //    }
   //  }
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::triggerObjectDetection, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::triggerObjectDetection, this),
                                       "detect objects");
 }
 
@@ -167,7 +167,7 @@ void MotionPlanningFrame::listenDetectedObjects(
     const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr /*msg*/)
 {
   rclcpp::sleep_for(std::chrono::seconds(1));
-  planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::processDetectedObjects, this));
+  planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::processDetectedObjects, this));
 }
 
 void MotionPlanningFrame::updateDetectedObjectsList(const std::vector<std::string>& object_ids)
@@ -197,7 +197,7 @@ void MotionPlanningFrame::updateDetectedObjectsList(const std::vector<std::strin
 void MotionPlanningFrame::updateTables()
 {
   RCLCPP_DEBUG(LOGGER, "Update table callback");
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::publishTables, this), "publish tables");
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::publishTables, this), "publish tables");
 }
 
 void MotionPlanningFrame::publishTables()
@@ -205,7 +205,7 @@ void MotionPlanningFrame::publishTables()
   // TODO (ddengster): Enable when moveit_ros_perception is ported
   // semantic_world_->addTablesToCollisionWorld();
 
-  planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::updateSupportSurfacesList, this));
+  planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::updateSupportSurfacesList, this));
 }
 
 void MotionPlanningFrame::selectedSupportSurfaceChanged()
@@ -303,7 +303,7 @@ void MotionPlanningFrame::pickObjectButtonClicked()
   //  }
   //  RCLCPP_INFO(LOGGER, "Trying to pick up object %s from support surface %s", pick_object_name_[group_name].c_str(),
   //           support_surface_name_.c_str());
-  //  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::pickObject, this), "pick");
+  //  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::pickObject, this), "pick");
 }
 
 void MotionPlanningFrame::placeObjectButtonClicked()
@@ -350,7 +350,7 @@ void MotionPlanningFrame::placeObjectButtonClicked()
   //                                                     upright_orientation, 0.1);
   //  planning_display_->visualizePlaceLocations(place_poses_);
   //  place_object_name_ = attached_bodies[0]->getName();
-  //  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::placeObject, this), "place");
+  //  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::placeObject, this), "place");
 }
 
 // void MotionPlanningFrame::pickObject()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -147,7 +147,7 @@ void MotionPlanningFrame::clearScene()
     ps->getPlanningSceneMsg(msg);
     planning_scene_publisher_->publish(msg);
     setLocalSceneEdited(false);
-    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+    planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
     planning_display_->queueRenderSceneGeometry();
   }
 }
@@ -220,7 +220,7 @@ void MotionPlanningFrame::removeSceneObject()
         ps->getCurrentStateNonConst().clearAttachedBody(sel[i]->text().toStdString());
     scene_marker_.reset();
     setLocalSceneEdited();
-    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+    planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
     planning_display_->queueRenderSceneGeometry();
   }
 }
@@ -490,7 +490,7 @@ void MotionPlanningFrame::copySelectedCollisionObject()
     RCLCPP_DEBUG(LOGGER, "Copied collision object to '%s'", name.c_str());
   }
   setLocalSceneEdited();
-  planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+  planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
 }
 
 void MotionPlanningFrame::computeSaveSceneButtonClicked()
@@ -510,7 +510,7 @@ void MotionPlanningFrame::computeSaveSceneButtonClicked()
   //      RCLCPP_ERROR(LOGGER, "%s", ex.what());
   //    }
   //
-  //    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //    planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
   //  }
 }
 
@@ -532,7 +532,7 @@ void MotionPlanningFrame::computeSaveQueryButtonClicked(const std::string& scene
   //      RCLCPP_ERROR(LOGGER, "%s", ex.what());
   //    }
   //
-  //    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //    planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
   //  }
 }
 
@@ -570,7 +570,7 @@ void MotionPlanningFrame::computeDeleteSceneButtonClicked()
   //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
   //        }
   //      }
-  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //      planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
   //    }
   //  }
 }
@@ -597,7 +597,7 @@ void MotionPlanningFrame::computeDeleteQueryButtonClicked()
   //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
   //        }
   //        planning_display_->addMainLoopJob(
-  //            boost::bind(&MotionPlanningFrame::computeDeleteQueryButtonClickedHelper, this, s));
+  //            std::bind(&MotionPlanningFrame::computeDeleteQueryButtonClickedHelper, this, s));
   //      }
   //    }
   //  }
@@ -850,7 +850,7 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       if (scene_marker_)
       {
         scene_marker_.reset();
-        planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::createSceneInteractiveMarker, this));
+        planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::createSceneInteractiveMarker, this));
       }
     }
   }
@@ -995,7 +995,7 @@ void MotionPlanningFrame::exportGeometryAsTextButtonClicked()
       QFileDialog::getSaveFileName(this, tr("Export Scene Geometry"), tr(""), tr("Scene Geometry (*.scene)"));
   if (!path.isEmpty())
     planning_display_->addBackgroundJob(
-        boost::bind(&MotionPlanningFrame::computeExportGeometryAsText, this, path.toStdString()), "export as text");
+        std::bind(&MotionPlanningFrame::computeExportGeometryAsText, this, path.toStdString()), "export as text");
 }
 
 void MotionPlanningFrame::computeExportGeometryAsText(const std::string& path)
@@ -1025,7 +1025,7 @@ void MotionPlanningFrame::computeImportGeometryFromText(const std::string& path)
     if (ps->loadGeometryFromStream(fin))
     {
       RCLCPP_INFO(LOGGER, "Loaded scene geometry from '%s'", path.c_str());
-      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+      planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
       planning_display_->queueRenderSceneGeometry();
       setLocalSceneEdited();
     }
@@ -1043,6 +1043,6 @@ void MotionPlanningFrame::importGeometryFromTextButtonClicked()
       QFileDialog::getOpenFileName(this, tr("Import Scene Geometry"), tr(""), tr("Scene Geometry (*.scene)"));
   if (!path.isEmpty())
     planning_display_->addBackgroundJob(
-        boost::bind(&MotionPlanningFrame::computeImportGeometryFromText, this, path.toStdString()), "import from text");
+        std::bind(&MotionPlanningFrame::computeImportGeometryFromText, this, path.toStdString()), "import from text");
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -55,7 +55,7 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualizatio
 void MotionPlanningFrame::planButtonClicked()
 {
   publishSceneIfNeeded();
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanButtonClicked, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computePlanButtonClicked, this),
                                       "compute plan");
 }
 
@@ -63,7 +63,7 @@ void MotionPlanningFrame::executeButtonClicked()
 {
   ui_->execute_button->setEnabled(false);
   // execution is done in a separate thread, to not block other background jobs by blocking for synchronous execution
-  planning_display_->spawnBackgroundJob(boost::bind(&MotionPlanningFrame::computeExecuteButtonClicked, this));
+  planning_display_->spawnBackgroundJob(std::bind(&MotionPlanningFrame::computeExecuteButtonClicked, this));
 }
 
 void MotionPlanningFrame::planAndExecuteButtonClicked()
@@ -72,13 +72,13 @@ void MotionPlanningFrame::planAndExecuteButtonClicked()
   ui_->plan_and_execute_button->setEnabled(false);
   ui_->execute_button->setEnabled(false);
   // execution is done in a separate thread, to not block other background jobs by blocking for synchronous execution
-  planning_display_->spawnBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanAndExecuteButtonClicked, this));
+  planning_display_->spawnBackgroundJob(std::bind(&MotionPlanningFrame::computePlanAndExecuteButtonClicked, this));
 }
 
 void MotionPlanningFrame::stopButtonClicked()
 {
   ui_->stop_button->setEnabled(false);  // avoid clicking again
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeStopButtonClicked, this), "stop");
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computeStopButtonClicked, this), "stop");
 }
 
 void MotionPlanningFrame::allowReplanningToggled(bool checked)
@@ -276,7 +276,7 @@ void MotionPlanningFrame::startStateTextChanged(const QString& start_state)
 {
   // use background job: fetching the current state might take up to a second
   planning_display_->addBackgroundJob(
-      boost::bind(&MotionPlanningFrame::startStateTextChangedExec, this, start_state.toStdString()),
+      std::bind(&MotionPlanningFrame::startStateTextChangedExec, this, start_state.toStdString()),
       "update start state");
 }
 
@@ -291,7 +291,7 @@ void MotionPlanningFrame::goalStateTextChanged(const QString& goal_state)
 {
   // use background job: fetching the current state might take up to a second
   planning_display_->addBackgroundJob(
-      boost::bind(&MotionPlanningFrame::goalStateTextChangedExec, this, goal_state.toStdString()), "update goal state");
+      std::bind(&MotionPlanningFrame::goalStateTextChangedExec, this, goal_state.toStdString()), "update goal state");
 }
 
 void MotionPlanningFrame::goalStateTextChangedExec(const std::string& goal_state)
@@ -434,7 +434,7 @@ void MotionPlanningFrame::populateConstraintsList()
 {
   if (move_group_)
     planning_display_->addMainLoopJob(
-        boost::bind(&MotionPlanningFrame::populateConstraintsList, this, move_group_->getKnownConstraints()));
+        std::bind(&MotionPlanningFrame::populateConstraintsList, this, move_group_->getKnownConstraints()));
 }
 
 void MotionPlanningFrame::populateConstraintsList(const std::vector<std::string>& constr)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -112,7 +112,7 @@ void MotionPlanningFrame::saveSceneButtonClicked()
   //      }
   //    }
   //
-  //    planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeSaveSceneButtonClicked, this),
+  //    planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computeSaveSceneButtonClicked, this),
   //                                        "save scene");
   //  }
 }
@@ -137,7 +137,7 @@ void MotionPlanningFrame::saveQueryButtonClicked()
   //      {
   //        std::string scene = s->text(0).toStdString();
   //        planning_display_->addBackgroundJob(
-  //            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, ""), "save query");
+  //            std::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, ""), "save query");
   //      }
   //      else
   //      {
@@ -182,7 +182,7 @@ void MotionPlanningFrame::saveQueryButtonClicked()
   //          }
   //        }
   //        planning_display_->addBackgroundJob(
-  //            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, query_name), "save
+  //            std::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, query_name), "save
   //            query");
   //      }
   //    }
@@ -191,25 +191,25 @@ void MotionPlanningFrame::saveQueryButtonClicked()
 
 void MotionPlanningFrame::deleteSceneButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeDeleteSceneButtonClicked, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computeDeleteSceneButtonClicked, this),
                                       "delete scene");
 }
 
 void MotionPlanningFrame::deleteQueryButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeDeleteQueryButtonClicked, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computeDeleteQueryButtonClicked, this),
                                       "delete query");
 }
 
 void MotionPlanningFrame::loadSceneButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadSceneButtonClicked, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computeLoadSceneButtonClicked, this),
                                       "load scene");
 }
 
 void MotionPlanningFrame::loadQueryButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadQueryButtonClicked, this),
+  planning_display_->addBackgroundJob(std::bind(&MotionPlanningFrame::computeLoadQueryButtonClicked, this),
                                       "load query");
 }
 
@@ -228,7 +228,7 @@ void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int co
   //
   //    if (planning_scene_storage->hasPlanningScene(new_name))
   //    {
-  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //      planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
   //      QMessageBox::warning(this, "Scene not renamed",
   //                           QString("The scene name '").append(item->text(column)).append("' already exists"));
   //      return;
@@ -246,7 +246,7 @@ void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int co
   //    std::string new_name = item->text(column).toStdString();
   //    if (planning_scene_storage->hasPlanningQuery(scene, new_name))
   //    {
-  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //      planning_display_->addMainLoopJob(std::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
   //      QMessageBox::warning(this, "Query not renamed", QString("The query name '")
   //                                                          .append(item->text(column))
   //                                                          .append("' already exists for scene ")

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -215,7 +215,7 @@ void PlanningSceneDisplay::reset()
   if (planning_scene_robot_)
     planning_scene_robot_->clear();
 
-  addBackgroundJob(boost::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
+  addBackgroundJob(std::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
   Display::reset();
 
   if (planning_scene_robot_)
@@ -392,7 +392,7 @@ void PlanningSceneDisplay::changedPlanningSceneTopic()
       service_name = rclcpp::names::append(getMoveGroupNS(), service_name);
     auto bg_func = [=]() {
       if (planning_scene_monitor_->requestPlanningSceneState(service_name))
-        addMainLoopJob(boost::bind(&PlanningSceneDisplay::onNewPlanningSceneState, this));
+        addMainLoopJob(std::bind(&PlanningSceneDisplay::onNewPlanningSceneState, this));
       else
         setStatus(rviz_common::properties::StatusProperty::Warn, "PlanningScene", "Requesting initial scene failed");
     };
@@ -533,7 +533,7 @@ void PlanningSceneDisplay::loadRobotModel()
   // we need to make sure the clearing of the robot model is in the main thread,
   // so that rendering operations do not have data removed from underneath,
   // so the next function is executed in the main loop
-  addMainLoopJob(boost::bind(&PlanningSceneDisplay::clearRobotModel, this));
+  addMainLoopJob(std::bind(&PlanningSceneDisplay::clearRobotModel, this));
 
   waitForAllMainLoopJobs();
 
@@ -542,8 +542,8 @@ void PlanningSceneDisplay::loadRobotModel()
   {
     planning_scene_monitor_.swap(psm);
     planning_scene_monitor_->addUpdateCallback(
-        boost::bind(&PlanningSceneDisplay::sceneMonitorReceivedUpdate, this, boost::placeholders::_1));
-    addMainLoopJob(boost::bind(&PlanningSceneDisplay::onRobotModelLoaded, this));
+        std::bind(&PlanningSceneDisplay::sceneMonitorReceivedUpdate, this, std::placeholders::_1));
+    addMainLoopJob(std::bind(&PlanningSceneDisplay::onRobotModelLoaded, this));
     setStatus(rviz_common::properties::StatusProperty::Ok, "PlanningScene", "Planning Scene Loaded Successfully");
     waitForAllMainLoopJobs();
   }
@@ -601,7 +601,7 @@ void PlanningSceneDisplay::onEnable()
 {
   Display::onEnable();
 
-  addBackgroundJob(boost::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
+  addBackgroundJob(std::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
 
   if (planning_scene_robot_)
   {

--- a/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
@@ -185,14 +185,14 @@ int main(int argc, char** argv)
       ROS_INFO(" * %s", name.c_str());
   }
 
-  psm.addUpdateCallback(boost::bind(&onSceneUpdate, &psm, &pss));
+  psm.addUpdateCallback(std::bind(&onSceneUpdate, &psm, &pss));
 
   boost::function<void(const moveit_msgs::msg::MotionPlanRequestConstPtr&)> callback1 =
-      boost::bind(&onMotionPlanRequest, boost::placeholders::_1, &psm, &pss);
+      std::bind(&onMotionPlanRequest, std::placeholders::_1, &psm, &pss);
   ros::Subscriber mplan_req_sub = nh.subscribe("motion_plan_request", 100, callback1);
-  boost::function<void(const moveit_msgs::msg::ConstraintsConstPtr&)> callback2 = boost::bind(&onConstraints, boost::placeholders::_1, &cs);
+  boost::function<void(const moveit_msgs::msg::ConstraintsConstPtr&)> callback2 = std::bind(&onConstraints, std::placeholders::_1, &cs);
   ros::Subscriber constr_sub = nh.subscribe("constraints", 100, callback2);
-  boost::function<void(const moveit_msgs::msg::RobotStateConstPtr&)> callback3 = boost::bind(&onRobotState, boost::placeholders::_1, &rs);
+  boost::function<void(const moveit_msgs::msg::RobotStateConstPtr&)> callback3 = std::bind(&onRobotState, std::placeholders::_1, &rs);
   ros::Subscriber state_sub = nh.subscribe("robot_state", 100, callback3);
 
   std::vector<std::string> topics;

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -183,27 +183,27 @@ int main(int argc, char** argv)
 
   boost::function<bool(moveit_msgs::srv::SaveRobotStateToWarehouse::Request & request,
                        moveit_msgs::srv::SaveRobotStateToWarehouse::Response & response)>
-      save_cb = boost::bind(&storeState, boost::placeholders::_1, boost::placeholders::_2, &rs);
+      save_cb = std::bind(&storeState, std::placeholders::_1, std::placeholders::_2, &rs);
 
   boost::function<bool(moveit_msgs::srv::ListRobotStatesInWarehouse::Request & request,
                        moveit_msgs::srv::ListRobotStatesInWarehouse::Response & response)>
-      list_cb = boost::bind(&listStates, boost::placeholders::_1, boost::placeholders::_2, &rs);
+      list_cb = std::bind(&listStates, std::placeholders::_1, std::placeholders::_2, &rs);
 
   boost::function<bool(moveit_msgs::srv::GetRobotStateFromWarehouse::Request & request,
                        moveit_msgs::srv::GetRobotStateFromWarehouse::Response & response)>
-      get_cb = boost::bind(&getState, boost::placeholders::_1, boost::placeholders::_2, &rs);
+      get_cb = std::bind(&getState, std::placeholders::_1, std::placeholders::_2, &rs);
 
   boost::function<bool(moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Request & request,
                        moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Response & response)>
-      has_cb = boost::bind(&hasState, boost::placeholders::_1, boost::placeholders::_2, &rs);
+      has_cb = std::bind(&hasState, std::placeholders::_1, std::placeholders::_2, &rs);
 
   boost::function<bool(moveit_msgs::srv::RenameRobotStateInWarehouse::Request & request,
                        moveit_msgs::srv::RenameRobotStateInWarehouse::Response & response)>
-      rename_cb = boost::bind(&renameState, boost::placeholders::_1, boost::placeholders::_2, &rs);
+      rename_cb = std::bind(&renameState, std::placeholders::_1, std::placeholders::_2, &rs);
 
   boost::function<bool(moveit_msgs::srv::DeleteRobotStateFromWarehouse::Request & request,
                        moveit_msgs::srv::DeleteRobotStateFromWarehouse::Response & response)>
-      delete_cb = boost::bind(&deleteState, boost::placeholders::_1, boost::placeholders::_2, &rs);
+      delete_cb = std::bind(&deleteState, std::placeholders::_1, std::placeholders::_2, &rs);
 
   ros::ServiceServer save_state_server = node.advertiseService("save_robot_state", save_cb);
   ros::ServiceServer list_states_server = node.advertiseService("list_robot_states", list_cb);

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -564,7 +564,7 @@ unsigned int disableNeverInCollision(const unsigned int num_trials, planning_sce
   for (int i = 0; i < num_threads; ++i)
   {
     ThreadComputation tc(scene, req, i, num_trials / num_threads, &links_seen_colliding, &lock, progress);
-    bgroup.create_thread(boost::bind(&disableNeverInCollisionThread, tc));
+    bgroup.create_thread(std::bind(&disableNeverInCollisionThread, tc));
   }
 
   try

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -204,7 +204,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = file.file_name_;
   template_path = config_data_->appendPaths(config_data_->template_package_path_, "package.xml.template");
   file.description_ = "Defines a ROS package";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::AUTHOR_INFO;
   gen_files_.push_back(file);
 
@@ -213,7 +213,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = file.file_name_;
   template_path = config_data_->appendPaths(config_data_->template_package_path_, file.file_name_);
   file.description_ = "CMake build system configuration file";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -227,7 +227,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = file.file_name_;
   file.description_ = "Folder containing all MoveIt configuration files for your robot. This folder is required and "
                       "cannot be disabled.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::createFolder, this, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::createFolder, this, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -241,7 +241,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
                       "representation of semantic information about robots. This format is intended to represent "
                       "information about the robot that is not in the URDF file, but it is useful for a variety of "
                       "applications. The intention is to include information that has a semantic aspect to it.";
-  file.gen_func_ = boost::bind(&srdf::SRDFWriter::writeSRDF, config_data_->srdf_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&srdf::SRDFWriter::writeSRDF, config_data_->srdf_, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::SRDF;
   gen_files_.push_back(file);
   // special step required so the generated .setup_assistant yaml has this value
@@ -258,7 +258,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
                       "planner_configs tag. While defining a planner configuration, the only mandatory parameter is "
                       "'type', which is the name of the motion planner to be used. Any other planner-specific "
                       "parameters can be defined but are optional.";
-  file.gen_func_ = boost::bind(&MoveItConfigData::outputOMPLPlanningYAML, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::outputOMPLPlanningYAML, config_data_, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::GROUPS;
   gen_files_.push_back(file);
 
@@ -266,7 +266,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.file_name_ = "chomp_planning.yaml";
   file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
   file.description_ = "Specifies which chomp planning plugin parameters to be used for the CHOMP planner";
-  file.gen_func_ = boost::bind(&MoveItConfigData::outputCHOMPPlanningYAML, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::outputCHOMPPlanningYAML, config_data_, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::GROUPS;  // need to double check if this is actually correct!
   gen_files_.push_back(file);
 
@@ -275,7 +275,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
   file.description_ = "Specifies which kinematic solver plugin to use for each planning group in the SRDF, as well as "
                       "the kinematic solver search resolution.";
-  file.gen_func_ = boost::bind(&MoveItConfigData::outputKinematicsYAML, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::outputKinematicsYAML, config_data_, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::GROUPS | MoveItConfigData::GROUP_KINEMATICS;
   gen_files_.push_back(file);
 
@@ -287,7 +287,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
                       "and acceleration than those contained in your URDF. This information is used by our trajectory "
                       "filtering system to assign reasonable velocities and timing for the trajectory before it is "
                       "passed to the robots controllers.";
-  file.gen_func_ = boost::bind(&MoveItConfigData::outputJointLimitsYAML, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::outputJointLimitsYAML, config_data_, std::placeholders::_1);
   file.write_on_changes = 0;  // Can they be changed?
   gen_files_.push_back(file);
 
@@ -296,7 +296,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
   file.description_ = "Creates dummy configurations for controllers that correspond to defined groups. This is mostly "
                       "useful for testing.";
-  file.gen_func_ = boost::bind(&MoveItConfigData::outputFakeControllersYAML, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::outputFakeControllersYAML, config_data_, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::GROUPS;
   gen_files_.push_back(file);
 
@@ -304,7 +304,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.file_name_ = "ros_controllers.yaml";
   file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
   file.description_ = "Creates configurations for ros_controllers.";
-  file.gen_func_ = boost::bind(&MoveItConfigData::outputROSControllersYAML, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::outputROSControllersYAML, config_data_, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::GROUPS;
   gen_files_.push_back(file);
 
@@ -312,7 +312,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.file_name_ = "sensors_3d.yaml";
   file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
   file.description_ = "Creates configurations 3d sensors.";
-  file.gen_func_ = boost::bind(&MoveItConfigData::output3DSensorPluginYAML, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::output3DSensorPluginYAML, config_data_, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::SENSORS_CONFIG;
   gen_files_.push_back(file);
 
@@ -327,7 +327,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = file.file_name_;
   file.description_ = "Folder containing all MoveIt launch files for your robot. "
                       "This folder is required and cannot be disabled.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::createFolder, this, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::createFolder, this, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -338,7 +338,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.description_ = "Launches the move_group node that provides the MoveGroup action and other parameters <a "
                       "href='http://moveit.ros.org/doxygen/"
                       "classmoveit_1_1planning__interface_1_1MoveGroup.html#details'>MoveGroup action</a>";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -348,7 +348,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Loads settings for the ROS parameter server, required for running MoveIt. This includes the "
                       "SRDF, joints_limits.yaml file, ompl_planning.yaml file, optionally the URDF, etc";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -358,7 +358,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Visualize in Rviz the robot's planning groups running with interactive markers that allow goal "
                       "states to be set.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -370,7 +370,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.description_ = "Intended to be included in other launch files that require the OMPL planning plugin. Defines "
                       "the proper plugin name on the parameter server and a default selection of planning request "
                       "adapters.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -382,7 +382,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.description_ = "Intended to be included in other launch files that require the CHOMP planning plugin. Defines "
                       "the proper plugin name on the parameter server and a default selection of planning request "
                       "adapters.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -391,7 +391,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Helper launch file that can choose between different planning pipelines to be loaded.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -400,7 +400,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Helper launch file that specifies default settings for MongoDB.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -409,7 +409,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Launch file for starting MongoDB.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -418,7 +418,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Launch file for starting the warehouse with a default MongoDB.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -427,7 +427,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Launch file for benchmarking OMPL planners";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -436,7 +436,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Helper launch file that can choose between different sensor managers to be loaded.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -445,7 +445,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, "moveit_controller_manager.launch.xml");
   file.description_ = "Placeholder for settings specific to the MoveIt controller manager implemented for you robot.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -454,7 +454,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, "moveit_sensor_manager.launch.xml");
   file.description_ = "Placeholder for settings specific to the MoveIt sensor manager implemented for you robot.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -464,7 +464,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Loads settings for the ROS parameter server required for executing trajectories using the "
                       "trajectory_execution_manager::TrajectoryExecutionManager.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(
       file);  // trajectory_execution.launch ------------------------------------------------------------------
@@ -473,7 +473,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Loads a fake controller plugin.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -482,7 +482,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Run a demo of MoveIt.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -492,7 +492,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   template_path = config_data_->appendPaths(template_launch_path, "gazebo.launch");
   file.description_ = "Gazebo launch file which also launches ros_controllers and sends robot urdf to param server, "
                       "then using gazebo_ros pkg the robot is spawned to Gazebo";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   gen_files_.push_back(file);
 
   // demo_gazebo.launch ------------------------------------------------------------------
@@ -500,7 +500,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Run a demo of MoveIt with Gazebo and Rviz";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -509,7 +509,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
   file.description_ = "Control the Rviz Motion Planning Plugin with a joystick";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -521,7 +521,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
                                                                    // up with the SA's real launch file
   file.description_ = "Launch file for easily re-starting the MoveIt Setup Assistant to edit this robot's generated "
                       "configuration package.";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -530,7 +530,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, "ros_controllers.launch");
   file.description_ = "ros_controllers launch file";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = MoveItConfigData::GROUPS;
   gen_files_.push_back(file);
 
@@ -540,7 +540,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   template_path = config_data_->appendPaths(template_launch_path, "moveit.rviz");
   file.description_ = "Configuration file for Rviz with the Motion Planning Plugin already setup. Used by passing "
                       "roslaunch moveit_rviz.launch config:=true";
-  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
 
@@ -552,7 +552,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.file_name_ = SETUP_ASSISTANT_FILE;
   file.rel_path_ = file.file_name_;
   file.description_ = "MoveIt Setup Assistant's hidden settings file. You should not need to edit this file.";
-  file.gen_func_ = boost::bind(&MoveItConfigData::outputSetupAssistantFile, config_data_, boost::placeholders::_1);
+  file.gen_func_ = std::bind(&MoveItConfigData::outputSetupAssistantFile, config_data_, std::placeholders::_1);
   file.write_on_changes = -1;  // write on any changes
   gen_files_.push_back(file);
 

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -225,7 +225,7 @@ void DefaultCollisionsWidget::startGeneratingCollisionTable()
   btn_revert_->setEnabled(true);  // allow to interrupt and revert
 
   // create a MonitorThread running generateCollisionTable() in a worker thread and monitoring the progress
-  worker_ = new MonitorThread(boost::bind(&DefaultCollisionsWidget::generateCollisionTable, this, boost::placeholders::_1), progress_bar_);
+  worker_ = new MonitorThread(std::bind(&DefaultCollisionsWidget::generateCollisionTable, this, std::placeholders::_1), progress_bar_);
   connect(worker_, SIGNAL(finished()), this, SLOT(finishGeneratingCollisionTable()));
   worker_->start();  // start after having finished() signal connected
 }
@@ -811,7 +811,7 @@ moveit_setup_assistant::MonitorThread::MonitorThread(const boost::function<void(
   : progress_(0), canceled_(false)
 {
   // start worker thread
-  worker_ = boost::thread(boost::bind(f, &progress_));
+  worker_ = boost::thread(std::bind(f, &progress_));
   // connect progress bar for updates
   if (progress_bar)
     connect(this, SIGNAL(progress(int)), progress_bar, SLOT(setValue(int)));


### PR DESCRIPTION
### Description

Replaces instances of boost::bind with std::bind and uses std::placeholders instead of boost::placeholders.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
