### PR TITLE
Switch order of compiler flags for virtual overload warning in ompl.

### DIFF
--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_planners_ompl)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wno-overloaded-virtual)
-endif()
-
 find_package(Boost REQUIRED system filesystem date_time thread serialization)
 find_package(moveit_common REQUIRED)
 find_package(moveit_core REQUIRED)
@@ -15,6 +11,10 @@ find_package(tf2_ros REQUIRED)
 find_package(ompl REQUIRED)
 
 moveit_package()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wno-overloaded-virtual)
+endif()
 
 include_directories(ompl_interface/include)
 include_directories(SYSTEM


### PR DESCRIPTION
### Description

Switched the order of the compiler flags because the clang build seemed to be having the virtual overload warning suppression overwritten.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
